### PR TITLE
chore(infra): Cloud Run deletion_protection を明示設定

### DIFF
--- a/infrastructure/environments/prd/main.tf
+++ b/infrastructure/environments/prd/main.tf
@@ -100,6 +100,7 @@ module "identity_platform" {
     "localhost",
     "${var.project_id}.firebaseapp.com",
     "${var.project_id}.web.app",
+    replace(module.cloudrun_admin.service_uri, "https://", ""),
   ]
   oauth_client_id     = var.oauth_client_id
   oauth_client_secret = var.oauth_client_secret

--- a/infrastructure/environments/stg/main.tf
+++ b/infrastructure/environments/stg/main.tf
@@ -85,6 +85,7 @@ module "identity_platform" {
     "localhost",
     "${var.project_id}.firebaseapp.com",
     "${var.project_id}.web.app",
+    replace(module.cloudrun_admin.service_uri, "https://", ""),
   ]
   oauth_client_id     = var.oauth_client_id
   oauth_client_secret = var.oauth_client_secret

--- a/infrastructure/modules/cloudrun_service/main.tf
+++ b/infrastructure/modules/cloudrun_service/main.tf
@@ -1,8 +1,9 @@
 resource "google_cloud_run_v2_service" "this" {
-  name     = var.service_name
-  location = var.region
-  project  = var.project_id
-  labels   = var.labels
+  name                = var.service_name
+  location            = var.region
+  project             = var.project_id
+  labels              = var.labels
+  deletion_protection = true
 
   template {
     service_account = var.service_account_email


### PR DESCRIPTION
## Summary
- Cloud Run サービスモジュールに `deletion_protection = true` を明示的に設定
- サービス名変更時に一時的に `false` にした後の復元

## Test plan
- [x] STG / PRD ともに `terraform apply` で適用済み