### PR TITLE
fix(frontend): COOP ヘッダーを Firebase Auth ポップアップと互換にする

### DIFF
--- a/applications/frontend/next.config.shared.ts
+++ b/applications/frontend/next.config.shared.ts
@@ -79,7 +79,7 @@ export const createBaseNextConfig = (options?: Options): NextConfig => {
           },
           {
             key: "Cross-Origin-Opener-Policy",
-            value: "same-origin",
+            value: "same-origin-allow-popups",
           },
           {
             key: "Cross-Origin-Resource-Policy",

--- a/infrastructure/environments/prd/main.tf
+++ b/infrastructure/environments/prd/main.tf
@@ -100,6 +100,7 @@ module "identity_platform" {
     "localhost",
     "${var.project_id}.firebaseapp.com",
     "${var.project_id}.web.app",
+    replace(module.cloudrun_admin.service_uri, "https://", ""),
   ]
   oauth_client_id     = var.oauth_client_id
   oauth_client_secret = var.oauth_client_secret

--- a/infrastructure/environments/stg/main.tf
+++ b/infrastructure/environments/stg/main.tf
@@ -85,6 +85,7 @@ module "identity_platform" {
     "localhost",
     "${var.project_id}.firebaseapp.com",
     "${var.project_id}.web.app",
+    replace(module.cloudrun_admin.service_uri, "https://", ""),
   ]
   oauth_client_id     = var.oauth_client_id
   oauth_client_secret = var.oauth_client_secret

--- a/infrastructure/modules/cloudrun_service/main.tf
+++ b/infrastructure/modules/cloudrun_service/main.tf
@@ -1,8 +1,9 @@
 resource "google_cloud_run_v2_service" "this" {
-  name     = var.service_name
-  location = var.region
-  project  = var.project_id
-  labels   = var.labels
+  name                = var.service_name
+  location            = var.region
+  project             = var.project_id
+  labels              = var.labels
+  deletion_protection = true
 
   template {
     service_account = var.service_account_email


### PR DESCRIPTION
## Summary
- `Cross-Origin-Opener-Policy: same-origin` → `same-origin-allow-popups` に変更
- `same-origin` は別オリジンのポップアップとの `postMessage` 通信を遮断するため、Firebase Auth の `signInWithPopup` が `auth/popup-closed-by-user` エラーで失敗していた

## Root Cause
PR #164（ペネトレーションテスト脆弱性の修正）で追加された COOP ヘッダーが Firebase Auth のポップアップ認証と干渉

## Test plan
- [ ] STG admin でログイン（signInWithPopup）が成功すること
- [ ] セキュリティヘッダーが正しく設定されていること