### PR TITLE
fix(infra): issue 33 公開前セキュリティ対応

### DIFF
--- a/infrastructure/environments/prd/main.tf
+++ b/infrastructure/environments/prd/main.tf
@@ -113,6 +113,7 @@ module "firebase_storage" {
   bucket_name        = "${var.project_id}.firebasestorage.app"
   location           = var.region
   versioning_enabled = true
+  rules_file         = "${path.module}/../../../storage.rules"
 
   labels = local.common_labels
 }

--- a/infrastructure/environments/stg/main.tf
+++ b/infrastructure/environments/stg/main.tf
@@ -97,6 +97,7 @@ module "firebase_storage" {
   project_id  = var.project_id
   bucket_name = "${var.project_id}.firebasestorage.app"
   location    = "US-EAST1"
+  rules_file  = "${path.module}/../../../storage.rules"
 
   labels = local.common_labels
 }

--- a/infrastructure/modules/firebase_storage/main.tf
+++ b/infrastructure/modules/firebase_storage/main.tf
@@ -22,3 +22,22 @@ resource "google_storage_bucket" "this" {
 
   labels = var.labels
 }
+
+resource "google_firebaserules_ruleset" "storage" {
+  count   = var.rules_file != null ? 1 : 0
+  project = var.project_id
+
+  source {
+    files {
+      name    = "storage.rules"
+      content = file(var.rules_file)
+    }
+  }
+}
+
+resource "google_firebaserules_release" "storage" {
+  count        = var.rules_file != null ? 1 : 0
+  project      = var.project_id
+  name         = "firebase.storage/${google_storage_bucket.this.name}"
+  ruleset_name = google_firebaserules_ruleset.storage[0].name
+}

--- a/infrastructure/modules/firebase_storage/variables.tf
+++ b/infrastructure/modules/firebase_storage/variables.tf
@@ -54,3 +54,9 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "rules_file" {
+  description = "Path to the Firebase Storage security rules file. If null, rules are not managed by Terraform."
+  type        = string
+  default     = null
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,21 +1,6 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /admin/{allPaths=**} {
-      allow read: if true;
-      allow write: if request.auth != null;
-    }
-
-    match /articles/{allPaths=**} {
-      allow read: if true;
-      allow write: if request.auth != null;
-    }
-
-    match /memos/{allPaths=**} {
-      allow read: if true;
-      allow write: if request.auth != null;
-    }
-
     match /{allPaths=**} {
       allow read: if true;
       allow write: if false;


### PR DESCRIPTION
## Summary
GitHub Issue #33 「公開前対応」への対応。

## 対応内容
- Firebase Storage ルールを Admin SDK 経由のみ許可に強化（`write: if false`）
- `infrastructure/modules/firebase_storage` に `google_firebaserules_ruleset` / `google_firebaserules_release` を追加して Terraform 管理化
- 環境 main.tf (stg/prd) で `rules_file` を渡す

## 対応外（Issue #33 で確認済み、意図通り）
- Firestore の広い read 権限（content-token-index, tags, site-documents, search-index, search-tokens, admin, index）→ reader アプリの Footer/検索で公開データとして使用中

## Test plan
- [ ] Terraform plan が正常に通ること
- [ ] storage.rules の構文が valid であること
- [ ] admin アプリの既存テスト（lint/build/unit/e2e）が pass すること
- [ ] 画像アップロード機能が Admin SDK 経由で動作すること

Closes #33