### PR TITLE
fix(frontend): トップページとコンテンツリストページの表示順を新しい順にする (#37)

### DIFF
--- a/applications/frontend/e2e/articles-list.spec.ts
+++ b/applications/frontend/e2e/articles-list.spec.ts
@@ -1,0 +1,169 @@
+import { expect, type Page, test } from "@playwright/test";
+
+type TestArgs = {
+  page: Page;
+};
+
+const publishedArticlesNewestFirst = [
+  {
+    slug: "mermaid-all-diagrams",
+    title: "Mermaid図 全サンプル集",
+  },
+  {
+    slug: "mermaid-diagram-test",
+    title: "Mermaid図を使った技術ドキュメント",
+  },
+  {
+    slug: "markdown-image-test",
+    title: "Markdownで画像を表示するテスト",
+  },
+  {
+    slug: "react-component-patterns",
+    title: "Reactコンポーネント設計パターン",
+  },
+  {
+    slug: "typescript-type-safe-code",
+    title: "TypeScriptで型安全なコードを書く",
+  },
+];
+
+const draftArticle = {
+  slug: "nextjs-app-router",
+  title: "Next.js App Routerの使い方",
+};
+
+test.describe("articles list page", () => {
+  test.describe("page structure", () => {
+    test("page loads successfully", async ({ page }: TestArgs) => {
+      await page.goto("/articles", { waitUntil: "load" });
+
+      await expect(page.locator("main")).toBeVisible();
+    });
+
+    test("displays ARTICLE section heading", async ({ page }: TestArgs) => {
+      await page.goto("/articles", { waitUntil: "load" });
+
+      await expect(
+        page.getByRole("heading", { name: "ARTICLE" }),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("display order", () => {
+    test("first article card in DOM is the newest article", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/articles", { waitUntil: "load" });
+
+      const articleCardLinks = page
+        .locator("main")
+        .getByRole("link")
+        .filter({ has: page.locator("article") });
+
+      await expect(articleCardLinks.first()).toBeVisible();
+
+      const firstLinkHref = await articleCardLinks
+        .first()
+        .getAttribute("href");
+      expect(firstLinkHref).toContain(
+        `/articles/${publishedArticlesNewestFirst[0].slug}`,
+      );
+
+      const firstCardTitle = articleCardLinks
+        .first()
+        .getByRole("heading", { level: 2 });
+      await expect(firstCardTitle).toHaveText(
+        publishedArticlesNewestFirst[0].title,
+      );
+    });
+
+    test("article cards appear in newest first order in DOM", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/articles", { waitUntil: "load" });
+
+      const articleCardLinks = page
+        .locator("main")
+        .getByRole("link")
+        .filter({ has: page.locator("article") });
+
+      await expect(articleCardLinks.first()).toBeVisible();
+
+      const hrefs = await articleCardLinks.evaluateAll((elements) =>
+        elements.map((element) => element.getAttribute("href") ?? ""),
+      );
+
+      const orderedSlugs = publishedArticlesNewestFirst.map(
+        (article) => article.slug,
+      );
+      const domIndices = orderedSlugs.map((slug) =>
+        hrefs.findIndex((href) => href.includes(`/articles/${slug}`)),
+      );
+
+      for (const index of domIndices) {
+        expect(index).toBeGreaterThanOrEqual(0);
+      }
+
+      for (let position = 1; position < domIndices.length; position += 1) {
+        expect(domIndices[position - 1]).toBeLessThan(domIndices[position]);
+      }
+    });
+
+    test("newest article appears above oldest article visually", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/articles", { waitUntil: "load" });
+
+      const oldestArticle =
+        publishedArticlesNewestFirst[publishedArticlesNewestFirst.length - 1];
+
+      const newestCard = page
+        .locator("main")
+        .getByRole("link")
+        .filter({ hasText: publishedArticlesNewestFirst[0].title })
+        .first();
+      const oldestCard = page
+        .locator("main")
+        .getByRole("link")
+        .filter({ hasText: oldestArticle.title })
+        .first();
+
+      await expect(newestCard).toBeVisible();
+      await expect(oldestCard).toBeVisible();
+
+      const newestBox = await newestCard.boundingBox();
+      const oldestBox = await oldestCard.boundingBox();
+
+      expect(newestBox).not.toBeNull();
+      expect(oldestBox).not.toBeNull();
+      expect(newestBox!.y).toBeLessThan(oldestBox!.y);
+    });
+  });
+
+  test.describe("published content", () => {
+    test("displays all published articles", async ({ page }: TestArgs) => {
+      await page.goto("/articles", { waitUntil: "load" });
+
+      for (const article of publishedArticlesNewestFirst) {
+        await expect(page.getByText(article.title).first()).toBeVisible();
+      }
+    });
+
+    test("does not display draft articles", async ({ page }: TestArgs) => {
+      await page.goto("/articles", { waitUntil: "load" });
+
+      await expect(page.getByText(draftArticle.title)).not.toBeVisible();
+    });
+  });
+
+  test.describe("responsiveness", () => {
+    test("page is viewable on mobile viewport", async ({ page }: TestArgs) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto("/articles", { waitUntil: "load" });
+
+      await expect(
+        page.getByRole("heading", { name: "ARTICLE" }),
+      ).toBeVisible();
+    });
+  });
+});

--- a/applications/frontend/e2e/home.spec.ts
+++ b/applications/frontend/e2e/home.spec.ts
@@ -33,6 +33,28 @@ const draftArticle = {
   title: "Next.js App Routerの使い方",
 };
 
+const publishedArticlesNewestFirst = [
+  {
+    slug: "mermaid-all-diagrams",
+    title: "Mermaid図 全サンプル集",
+  },
+  {
+    slug: "mermaid-diagram-test",
+    title: "Mermaid図を使った技術ドキュメント",
+  },
+];
+
+const publishedSeriesNewestFirst = [
+  {
+    slug: "typescript-design-patterns",
+    title: "実践TypeScript設計パターン",
+  },
+  {
+    slug: "rust-system-programming",
+    title: "Rustで学ぶシステムプログラミング",
+  },
+];
+
 // シードデータの公開メモ情報 (下書きを除く)
 const publishedMemos = [
   {
@@ -458,6 +480,93 @@ test.describe("home page", () => {
 
       const href = await viewMoreLink.getAttribute("href");
       expect(href).toBe("/series");
+    });
+  });
+
+  test.describe("display order", () => {
+    test("article section lists cards in newest first order", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/", { waitUntil: "load" });
+
+      const articleSection = page.locator("section").filter({
+        has: page.getByRole("heading", { name: "ARTICLE" }),
+      });
+
+      const articleCardLinks = articleSection
+        .getByRole("link")
+        .filter({ has: page.locator("article") });
+
+      await expect(articleCardLinks.first()).toBeVisible();
+
+      const firstHref = await articleCardLinks.first().getAttribute("href");
+      expect(firstHref).toContain(
+        `/articles/${publishedArticlesNewestFirst[0].slug}`,
+      );
+
+      const hrefs = await articleCardLinks.evaluateAll((elements) =>
+        elements.map((element) => element.getAttribute("href") ?? ""),
+      );
+      const newestIndex = hrefs.findIndex((href) =>
+        href.includes(`/articles/${publishedArticlesNewestFirst[0].slug}`),
+      );
+      const secondIndex = hrefs.findIndex((href) =>
+        href.includes(`/articles/${publishedArticlesNewestFirst[1].slug}`),
+      );
+      expect(newestIndex).toBeGreaterThanOrEqual(0);
+      expect(secondIndex).toBeGreaterThan(newestIndex);
+    });
+
+    test("memo section lists the newest memo as the first card", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/", { waitUntil: "load" });
+
+      const memoSection = page.locator("section").filter({
+        has: page.getByRole("heading", { name: "MEMO" }),
+      });
+
+      const memoCardLinks = memoSection
+        .getByRole("link")
+        .filter({ has: page.locator("article") });
+
+      await expect(memoCardLinks.first()).toBeVisible();
+
+      const firstHref = await memoCardLinks.first().getAttribute("href");
+      expect(firstHref).toContain(`/memos/${publishedMemos[0].slug}`);
+    });
+
+    test("series section lists cards in newest first order", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/", { waitUntil: "load" });
+
+      const seriesSection = page.locator("section").filter({
+        has: page.getByRole("heading", { name: "SERIES" }),
+      });
+
+      const seriesCardLinks = seriesSection
+        .getByRole("link")
+        .filter({ has: page.locator("article") });
+
+      await expect(seriesCardLinks.first()).toBeVisible();
+
+      const firstHref = await seriesCardLinks.first().getAttribute("href");
+      expect(firstHref).toContain(
+        `/series/${publishedSeriesNewestFirst[0].slug}`,
+      );
+
+      const hrefs = await seriesCardLinks.evaluateAll((elements) =>
+        elements.map((element) => element.getAttribute("href") ?? ""),
+      );
+      const newestIndex = hrefs.findIndex((href) =>
+        href.includes(`/series/${publishedSeriesNewestFirst[0].slug}`),
+      );
+      const olderIndex = hrefs.findIndex((href) =>
+        href.includes(`/series/${publishedSeriesNewestFirst[1].slug}`),
+      );
+      expect(newestIndex).toBeGreaterThanOrEqual(0);
+      expect(olderIndex).toBeGreaterThan(newestIndex);
     });
   });
 

--- a/applications/frontend/e2e/memos-list.spec.ts
+++ b/applications/frontend/e2e/memos-list.spec.ts
@@ -1,0 +1,91 @@
+import { expect, type Page, test } from "@playwright/test";
+
+type TestArgs = {
+  page: Page;
+};
+
+const publishedMemosNewestFirst = [
+  {
+    slug: "go-tips",
+    title: "Go言語のTips",
+  },
+];
+
+const draftMemo = {
+  slug: "typescript-config",
+  title: "TypeScript設定メモ",
+};
+
+test.describe("memos list page", () => {
+  test.describe("page structure", () => {
+    test("page loads successfully", async ({ page }: TestArgs) => {
+      await page.goto("/memos", { waitUntil: "load" });
+
+      await expect(page.locator("main")).toBeVisible();
+    });
+
+    test("displays MEMO section heading", async ({ page }: TestArgs) => {
+      await page.goto("/memos", { waitUntil: "load" });
+
+      await expect(
+        page.getByRole("heading", { name: "MEMO" }),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("display order", () => {
+    test("first memo card in DOM is the newest memo", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/memos", { waitUntil: "load" });
+
+      const memoCardLinks = page
+        .locator("main")
+        .getByRole("link")
+        .filter({ has: page.locator("article") });
+
+      await expect(memoCardLinks.first()).toBeVisible();
+
+      const firstLinkHref = await memoCardLinks
+        .first()
+        .getAttribute("href");
+      expect(firstLinkHref).toContain(
+        `/memos/${publishedMemosNewestFirst[0].slug}`,
+      );
+
+      const firstCardTitle = memoCardLinks
+        .first()
+        .getByRole("heading", { level: 2 });
+      await expect(firstCardTitle).toHaveText(
+        publishedMemosNewestFirst[0].title,
+      );
+    });
+  });
+
+  test.describe("published content", () => {
+    test("displays all published memos", async ({ page }: TestArgs) => {
+      await page.goto("/memos", { waitUntil: "load" });
+
+      for (const memo of publishedMemosNewestFirst) {
+        await expect(page.getByText(memo.title).first()).toBeVisible();
+      }
+    });
+
+    test("does not display draft memos", async ({ page }: TestArgs) => {
+      await page.goto("/memos", { waitUntil: "load" });
+
+      await expect(page.getByText(draftMemo.title)).not.toBeVisible();
+    });
+  });
+
+  test.describe("responsiveness", () => {
+    test("page is viewable on mobile viewport", async ({ page }: TestArgs) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto("/memos", { waitUntil: "load" });
+
+      await expect(
+        page.getByRole("heading", { name: "MEMO" }),
+      ).toBeVisible();
+    });
+  });
+});

--- a/applications/frontend/e2e/series-list.spec.ts
+++ b/applications/frontend/e2e/series-list.spec.ts
@@ -1,0 +1,127 @@
+import { expect, type Page, test } from "@playwright/test";
+
+type TestArgs = {
+  page: Page;
+};
+
+const publishedSeriesNewestFirst = [
+  {
+    slug: "typescript-design-patterns",
+    title: "実践TypeScript設計パターン",
+  },
+  {
+    slug: "rust-system-programming",
+    title: "Rustで学ぶシステムプログラミング",
+  },
+];
+
+const draftSeries = {
+  slug: "nextjs-fullstack-application",
+  title: "Next.jsで作るフルスタックアプリケーション",
+};
+
+test.describe("series list page ordering", () => {
+  test.describe("display order", () => {
+    test("first series card in DOM is the newest series", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/series", { waitUntil: "load" });
+
+      const seriesCardLinks = page
+        .locator("main")
+        .getByRole("link")
+        .filter({ has: page.locator("article") });
+
+      await expect(seriesCardLinks.first()).toBeVisible();
+
+      const firstLinkHref = await seriesCardLinks
+        .first()
+        .getAttribute("href");
+      expect(firstLinkHref).toContain(
+        `/series/${publishedSeriesNewestFirst[0].slug}`,
+      );
+
+      const firstCardTitle = seriesCardLinks
+        .first()
+        .getByRole("heading", { level: 2 });
+      await expect(firstCardTitle).toHaveText(
+        publishedSeriesNewestFirst[0].title,
+      );
+    });
+
+    test("series cards appear in newest first order in DOM", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/series", { waitUntil: "load" });
+
+      const seriesCardLinks = page
+        .locator("main")
+        .getByRole("link")
+        .filter({ has: page.locator("article") });
+
+      await expect(seriesCardLinks.first()).toBeVisible();
+
+      const hrefs = await seriesCardLinks.evaluateAll((elements) =>
+        elements.map((element) => element.getAttribute("href") ?? ""),
+      );
+
+      const newestIndex = hrefs.findIndex((href) =>
+        href.includes(`/series/${publishedSeriesNewestFirst[0].slug}`),
+      );
+      const secondIndex = hrefs.findIndex((href) =>
+        href.includes(`/series/${publishedSeriesNewestFirst[1].slug}`),
+      );
+
+      expect(newestIndex).toBeGreaterThanOrEqual(0);
+      expect(secondIndex).toBeGreaterThanOrEqual(0);
+      expect(newestIndex).toBeLessThan(secondIndex);
+    });
+
+    test("newest series appears above older series visually", async ({
+      page,
+    }: TestArgs) => {
+      await page.goto("/series", { waitUntil: "load" });
+
+      const newestSeriesCard = page
+        .locator("main")
+        .getByRole("link")
+        .filter({
+          hasText: publishedSeriesNewestFirst[0].title,
+        })
+        .first();
+      const olderSeriesCard = page
+        .locator("main")
+        .getByRole("link")
+        .filter({
+          hasText: publishedSeriesNewestFirst[1].title,
+        })
+        .first();
+
+      await expect(newestSeriesCard).toBeVisible();
+      await expect(olderSeriesCard).toBeVisible();
+
+      const newestBox = await newestSeriesCard.boundingBox();
+      const olderBox = await olderSeriesCard.boundingBox();
+
+      expect(newestBox).not.toBeNull();
+      expect(olderBox).not.toBeNull();
+      expect(newestBox!.y).toBeLessThan(olderBox!.y);
+    });
+  });
+
+  test.describe("published content", () => {
+    test("displays all published series", async ({ page }: TestArgs) => {
+      await page.goto("/series", { waitUntil: "load" });
+
+      for (const series of publishedSeriesNewestFirst) {
+        await expect(page.getByText(series.title).first()).toBeVisible();
+      }
+    });
+
+    test("does not display draft series", async ({ page }: TestArgs) => {
+      await page.goto("/series", { waitUntil: "load" });
+
+      await expect(page.getByText(draftSeries.title)).not.toBeVisible();
+    });
+  });
+});

--- a/applications/frontend/playwright.config.ts
+++ b/applications/frontend/playwright.config.ts
@@ -81,11 +81,14 @@ const readerBaseURL = process.env.READER_BASE_URL ?? "http://localhost:3000";
 const readerTestFiles = [
   "**/accessibility.spec.ts",
   "**/article-detail.spec.ts",
+  "**/articles-list.spec.ts",
   "**/memo-detail.spec.ts",
+  "**/memos-list.spec.ts",
   "**/home.spec.ts",
   "**/public-pages.spec.ts",
   "**/search.spec.ts",
   "**/series.spec.ts",
+  "**/series-list.spec.ts",
 ];
 
 /**

--- a/applications/frontend/shared/src/domains/articles/common.ts
+++ b/applications/frontend/shared/src/domains/articles/common.ts
@@ -15,6 +15,7 @@ import {
   slugSchema,
   timelineSchema,
 } from "../common";
+import { sortByFieldSchema, orderSchema } from "../common/sort";
 import { tagIdentifierSchema } from "../attributes/tag";
 import { imageIdentifierSchema } from "../image/identifier";
 
@@ -120,6 +121,8 @@ export const criteriaSchema = z
     status: publishStatusSchema.nullish(),
     freeWord: z.string().min(1).max(100).nullish(),
     tags: z.array(tagIdentifierSchema).nullish(),
+    sortBy: sortByFieldSchema.nullish(),
+    order: orderSchema.nullish(),
   })
   .brand("Criteria");
 
@@ -134,6 +137,8 @@ export type UnvalidatedCriteria = {
   status?: string | null;
   freeWord?: string | null;
   tags?: string[] | null;
+  sortBy?: string | null;
+  order?: string | null;
 };
 
 export const articleSnapshotSchema = z

--- a/applications/frontend/shared/src/domains/common/index.ts
+++ b/applications/frontend/shared/src/domains/common/index.ts
@@ -5,3 +5,4 @@ export * from "./event";
 export * from "./collections";
 export * from "./slug";
 export * from "./image-upload";
+export * from "./sort";

--- a/applications/frontend/shared/src/domains/common/sort.ts
+++ b/applications/frontend/shared/src/domains/common/sort.ts
@@ -1,0 +1,21 @@
+import z from "zod";
+
+export const sortByFieldSchema = z
+  .enum(["createdAt", "updatedAt"])
+  .brand("SortByField");
+
+export type SortByField = z.infer<typeof sortByFieldSchema>;
+
+export const SortByField = {
+  CREATED_AT: sortByFieldSchema.parse("createdAt"),
+  UPDATED_AT: sortByFieldSchema.parse("updatedAt"),
+} as const;
+
+export const orderSchema = z.enum(["asc", "desc"]).brand("Order");
+
+export type Order = z.infer<typeof orderSchema>;
+
+export const Order = {
+  ASC: orderSchema.parse("asc"),
+  DESC: orderSchema.parse("desc"),
+} as const;

--- a/applications/frontend/shared/src/domains/memo/common.ts
+++ b/applications/frontend/shared/src/domains/memo/common.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 import { publishStatusSchema, Slug, slugSchema } from "../common";
 import { timelineSchema } from "../common/date";
+import { sortByFieldSchema, orderSchema } from "../common/sort";
 import { AsyncResult, err, ok, Result } from "@shared/aspects/result";
 import {
   AggregateNotFoundError,
@@ -132,6 +133,8 @@ export const criteriaSchema = z
     tags: z.array(tagIdentifierSchema).nullable(),
     freeWord: z.string().min(1).max(100).nullable(),
     status: publishStatusSchema.nullable(),
+    sortBy: sortByFieldSchema.nullable().default(null),
+    order: orderSchema.nullable().default(null),
   })
   .brand("Criteria");
 
@@ -141,6 +144,8 @@ export type UnvalidatedCriteria = {
   tags: string[] | null;
   freeWord: string | null;
   status: string | null;
+  sortBy?: string | null;
+  order?: string | null;
 };
 
 export const validateCriteria = (

--- a/applications/frontend/shared/src/domains/series/common.ts
+++ b/applications/frontend/shared/src/domains/series/common.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 import { publishStatusSchema, Slug, slugSchema } from "../common";
 import { timelineSchema } from "../common/date";
+import { sortByFieldSchema, orderSchema } from "../common/sort";
 import { AsyncResult, err, ok, Result } from "@shared/aspects/result";
 import {
   AggregateNotFoundError,
@@ -117,6 +118,8 @@ export const criteriaSchema = z
     tags: z.array(tagIdentifierSchema).nullable(),
     status: publishStatusSchema.nullable(),
     freeWord: z.string().min(1).max(100).nullable(),
+    sortBy: sortByFieldSchema.nullable().default(null),
+    order: orderSchema.nullable().default(null),
   })
   .brand("Criteria");
 
@@ -127,6 +130,8 @@ export type UnvalidatedCriteria = {
   tags: string[] | null;
   status: string | null;
   freeWord: string | null;
+  sortBy?: string | null;
+  order?: string | null;
 };
 
 export const validateCriteria = (

--- a/applications/frontend/shared/src/infrastructures/articles.ts
+++ b/applications/frontend/shared/src/infrastructures/articles.ts
@@ -20,6 +20,7 @@ import {
   Criteria,
   validateArticle,
 } from "@shared/domains/articles";
+import { Order, SortByField } from "@shared/domains/common/sort";
 import { fromPromise } from "@shared/aspects/result";
 import {
   aggregateNotFoundError,
@@ -249,6 +250,12 @@ export const FirebaseArticleRepository = (
             operations.where("tags", "array-contains-any", criteria.tags),
           );
         }
+
+        const sortByField = criteria.sortBy ?? SortByField.CREATED_AT;
+        const sortOrder = criteria.order ?? Order.DESC;
+        constraints.push(
+          operations.orderBy(`timeline.${sortByField}`, sortOrder),
+        );
 
         const q = operations.query(collection, ...constraints);
         const querySnapshot = await operations.getDocs(q);

--- a/applications/frontend/shared/src/infrastructures/memos.ts
+++ b/applications/frontend/shared/src/infrastructures/memos.ts
@@ -21,6 +21,7 @@ import {
   MemoSlug,
   validateMemo,
 } from "@shared/domains/memo";
+import { Order, SortByField } from "@shared/domains/common/sort";
 import { fromPromise } from "@shared/aspects/result";
 import {
   aggregateNotFoundError,
@@ -195,6 +196,12 @@ export const FirebaseMemoRepository = (
             operations.where("tags", "array-contains-any", criteria.tags),
           );
         }
+
+        const sortByField = criteria.sortBy ?? SortByField.CREATED_AT;
+        const sortOrder = criteria.order ?? Order.DESC;
+        constraints.push(
+          operations.orderBy(`timeline.${sortByField}`, sortOrder),
+        );
 
         const q = operations.query(collection, ...constraints);
         const querySnapshot = await operations.getDocs(q);

--- a/applications/frontend/shared/src/infrastructures/series.ts
+++ b/applications/frontend/shared/src/infrastructures/series.ts
@@ -21,6 +21,7 @@ import {
   SeriesSlug,
   validateSeries,
 } from "@shared/domains/series";
+import { Order, SortByField } from "@shared/domains/common/sort";
 import { fromPromise } from "@shared/aspects/result";
 import {
   aggregateNotFoundError,
@@ -222,6 +223,12 @@ export const FirebaseSeriesRepository = (
             operations.where("tags", "array-contains-any", criteria.tags),
           );
         }
+
+        const sortByField = criteria.sortBy ?? SortByField.CREATED_AT;
+        const sortOrder = criteria.order ?? Order.DESC;
+        constraints.push(
+          operations.orderBy(`timeline.${sortByField}`, sortOrder),
+        );
 
         const q = operations.query(collection, ...constraints);
         const querySnapshot = await operations.getDocs(q);

--- a/applications/frontend/shared/tests/domains/articles/common.test.ts
+++ b/applications/frontend/shared/tests/domains/articles/common.test.ts
@@ -15,6 +15,7 @@ import {
   validateCriteria,
 } from "@shared/domains/articles";
 import { PublishStatus } from "@shared/domains/common";
+import { SortByField, Order } from "@shared/domains/common/sort";
 import {
   ArticleMold,
   ArticleIdentifierMold,
@@ -286,6 +287,114 @@ describe("domains/articles/common", () => {
         tags: null,
       });
       expect(result.isErr).toBe(true);
+    });
+  });
+
+  describe("criteriaSchema sortBy/order", () => {
+    it("sortByにcreatedAtを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+        sortBy: SortByField.CREATED_AT,
+        order: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("sortByにupdatedAtを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+        sortBy: SortByField.UPDATED_AT,
+        order: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("orderにascを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+        sortBy: null,
+        order: Order.ASC,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("orderにdescを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+        sortBy: null,
+        order: Order.DESC,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("sortByとorderを省略しても有効", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("不正なsortByは無効", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+        sortBy: "invalid-field",
+        order: null,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("不正なorderは無効", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+        sortBy: null,
+        order: "invalid-order",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("sortByとorderをnullにして有効なCriteriaを生成できる", () => {
+      const result = validateCriteria({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+        sortBy: null,
+        order: null,
+      });
+      expect(result.isOk).toBe(true);
+    });
+
+    it("sortByとorderを指定して有効なCriteriaを生成できる", () => {
+      const result = validateCriteria({
+        slug: null,
+        status: null,
+        freeWord: null,
+        tags: null,
+        sortBy: "createdAt",
+        order: "desc",
+      });
+      expect(result.isOk).toBe(true);
     });
   });
 });

--- a/applications/frontend/shared/tests/domains/common/sort.test.ts
+++ b/applications/frontend/shared/tests/domains/common/sort.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  sortByFieldSchema,
+  orderSchema,
+  SortByField,
+  Order,
+} from "@shared/domains/common/sort";
+
+describe("domains/common/sort", () => {
+  describe("sortByFieldSchema", () => {
+    it("createdAtを受け入れる", () => {
+      const result = sortByFieldSchema.safeParse("createdAt");
+      expect(result.success).toBe(true);
+    });
+
+    it("updatedAtを受け入れる", () => {
+      const result = sortByFieldSchema.safeParse("updatedAt");
+      expect(result.success).toBe(true);
+    });
+
+    it("不正値はパースに失敗する", () => {
+      const result = sortByFieldSchema.safeParse("invalid");
+      expect(result.success).toBe(false);
+    });
+
+    it("空文字列はパースに失敗する", () => {
+      const result = sortByFieldSchema.safeParse("");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("orderSchema", () => {
+    it("ascを受け入れる", () => {
+      const result = orderSchema.safeParse("asc");
+      expect(result.success).toBe(true);
+    });
+
+    it("descを受け入れる", () => {
+      const result = orderSchema.safeParse("desc");
+      expect(result.success).toBe(true);
+    });
+
+    it("不正値はパースに失敗する", () => {
+      const result = orderSchema.safeParse("invalid");
+      expect(result.success).toBe(false);
+    });
+
+    it("空文字列はパースに失敗する", () => {
+      const result = orderSchema.safeParse("");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("SortByField定数", () => {
+    it("CREATED_ATはcreatedAtを返す", () => {
+      expect(SortByField.CREATED_AT).toBe("createdAt");
+    });
+
+    it("UPDATED_ATはupdatedAtを返す", () => {
+      expect(SortByField.UPDATED_AT).toBe("updatedAt");
+    });
+  });
+
+  describe("Order定数", () => {
+    it("ASCはascを返す", () => {
+      expect(Order.ASC).toBe("asc");
+    });
+
+    it("DESCはdescを返す", () => {
+      expect(Order.DESC).toBe("desc");
+    });
+  });
+});

--- a/applications/frontend/shared/tests/domains/memo/common.test.ts
+++ b/applications/frontend/shared/tests/domains/memo/common.test.ts
@@ -13,6 +13,7 @@ import {
   criteriaSchema,
   validateCriteria,
 } from "@shared/domains/memo";
+import { SortByField, Order } from "@shared/domains/common/sort";
 import {
   MemoMold,
   MemoIdentifierMold,
@@ -319,6 +320,90 @@ describe("domains/memo/common", () => {
     it("無効なCriteriaでerrを返す", () => {
       const result = validateCriteria({ tags: null, freeWord: "", status: null });
       expect(result.isErr).toBe(true);
+    });
+  });
+
+  describe("criteriaSchema sortBy/order", () => {
+    it("sortByにcreatedAtを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        tags: null,
+        freeWord: null,
+        status: null,
+        sortBy: SortByField.CREATED_AT,
+        order: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("sortByにupdatedAtを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        tags: null,
+        freeWord: null,
+        status: null,
+        sortBy: SortByField.UPDATED_AT,
+        order: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("orderにascを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        tags: null,
+        freeWord: null,
+        status: null,
+        sortBy: null,
+        order: Order.ASC,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("orderにdescを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        tags: null,
+        freeWord: null,
+        status: null,
+        sortBy: null,
+        order: Order.DESC,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("sortByとorderを省略しても有効", () => {
+      const result = criteriaSchema.safeParse({ tags: null, freeWord: null, status: null });
+      expect(result.success).toBe(true);
+    });
+
+    it("不正なsortByは無効", () => {
+      const result = criteriaSchema.safeParse({
+        tags: null,
+        freeWord: null,
+        status: null,
+        sortBy: "invalid-field",
+        order: null,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("不正なorderは無効", () => {
+      const result = criteriaSchema.safeParse({
+        tags: null,
+        freeWord: null,
+        status: null,
+        sortBy: null,
+        order: "invalid-order",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("sortByとorderを指定して有効なCriteriaを生成できる", () => {
+      const result = validateCriteria({
+        tags: null,
+        freeWord: null,
+        status: null,
+        sortBy: "createdAt",
+        order: "desc",
+      });
+      expect(result.isOk).toBe(true);
     });
   });
 });

--- a/applications/frontend/shared/tests/domains/series/common.test.ts
+++ b/applications/frontend/shared/tests/domains/series/common.test.ts
@@ -14,6 +14,7 @@ import {
   criteriaSchema,
   validateCriteria,
 } from "@shared/domains/series";
+import { SortByField, Order } from "@shared/domains/common/sort";
 import { chapterIdentifierSchema } from "@shared/domains/series/chapter";
 import { PublishStatus } from "@shared/domains/common";
 import {
@@ -411,6 +412,97 @@ describe("domains/series/common", () => {
     it("無効なCriteriaでerrを返す", () => {
       const result = validateCriteria({ slug: "Invalid Slug", tags: null, status: null, freeWord: null });
       expect(result.isErr).toBe(true);
+    });
+  });
+
+  describe("criteriaSchema sortBy/order", () => {
+    it("sortByにcreatedAtを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        tags: null,
+        status: null,
+        freeWord: null,
+        sortBy: SortByField.CREATED_AT,
+        order: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("sortByにupdatedAtを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        tags: null,
+        status: null,
+        freeWord: null,
+        sortBy: SortByField.UPDATED_AT,
+        order: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("orderにascを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        tags: null,
+        status: null,
+        freeWord: null,
+        sortBy: null,
+        order: Order.ASC,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("orderにdescを指定できる", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        tags: null,
+        status: null,
+        freeWord: null,
+        sortBy: null,
+        order: Order.DESC,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("sortByとorderを省略しても有効", () => {
+      const result = criteriaSchema.safeParse({ slug: null, tags: null, status: null, freeWord: null });
+      expect(result.success).toBe(true);
+    });
+
+    it("不正なsortByは無効", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        tags: null,
+        status: null,
+        freeWord: null,
+        sortBy: "invalid-field",
+        order: null,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("不正なorderは無効", () => {
+      const result = criteriaSchema.safeParse({
+        slug: null,
+        tags: null,
+        status: null,
+        freeWord: null,
+        sortBy: null,
+        order: "invalid-order",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("sortByとorderを指定して有効なCriteriaを生成できる", () => {
+      const result = validateCriteria({
+        slug: null,
+        tags: null,
+        status: null,
+        freeWord: null,
+        sortBy: "createdAt",
+        order: "desc",
+      });
+      expect(result.isOk).toBe(true);
     });
   });
 });

--- a/applications/frontend/shared/tests/infrastructures/articles.test.ts
+++ b/applications/frontend/shared/tests/infrastructures/articles.test.ts
@@ -24,6 +24,7 @@ import {
   type ArticleSlug,
 } from "@shared/domains/articles";
 import type { FirestoreOperations } from "@shared/infrastructures/common";
+import { TimelineMold } from "../support/molds/domains/common/date";
 
 describe("infrastructures/articles", () => {
   let firestore: Firestore;
@@ -48,12 +49,16 @@ describe("infrastructures/articles", () => {
     status?: PublishStatus | null;
     freeWord?: string | null;
     tags?: TagIdentifier[] | null;
+    sortBy?: string | null;
+    order?: string | null;
   }): Criteria => {
     return validateCriteria({
       slug: params.slug ?? null,
       status: params.status ?? null,
       freeWord: params.freeWord ?? null,
       tags: params.tags ?? null,
+      sortBy: params.sortBy ?? null,
+      order: params.order ?? null,
     }).unwrap();
   };
 
@@ -455,6 +460,99 @@ describe("infrastructures/articles", () => {
 
         expect(found.length).toBe(1);
         expect(found[0]?.identifier).toBe(article1.identifier);
+      });
+    });
+
+    describe("search ordering", () => {
+      it("デフォルトでcreatedAt降順で返る", async () => {
+        const repository = FirebaseArticleRepository(
+          firestore,
+          getOperations(),
+        );
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-02-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+        const timeline3 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-03-01T00:00:00Z"),
+          updatedAt: new Date("2024-03-01T00:00:00Z"),
+        });
+
+        const article1 = Forger(ArticleMold).forgeWithSeed(300, { timeline: timeline1 });
+        const article2 = Forger(ArticleMold).forgeWithSeed(301, { timeline: timeline2 });
+        const article3 = Forger(ArticleMold).forgeWithSeed(302, { timeline: timeline3 });
+
+        await repository.persist(article1).unwrap();
+        await repository.persist(article2).unwrap();
+        await repository.persist(article3).unwrap();
+
+        const criteria = createCriteria({});
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(3);
+        expect(found[0]?.identifier).toBe(article3.identifier);
+        expect(found[1]?.identifier).toBe(article2.identifier);
+        expect(found[2]?.identifier).toBe(article1.identifier);
+      });
+
+      it("order: ascを指定すると昇順で返る", async () => {
+        const repository = FirebaseArticleRepository(
+          firestore,
+          getOperations(),
+        );
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-02-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+
+        const article1 = Forger(ArticleMold).forgeWithSeed(310, { timeline: timeline1 });
+        const article2 = Forger(ArticleMold).forgeWithSeed(311, { timeline: timeline2 });
+
+        await repository.persist(article1).unwrap();
+        await repository.persist(article2).unwrap();
+
+        const criteria = createCriteria({ order: "asc" });
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(2);
+        expect(found[0]?.identifier).toBe(article1.identifier);
+        expect(found[1]?.identifier).toBe(article2.identifier);
+      });
+
+      it("sortBy: updatedAtを指定するとupdatedAt降順で返る", async () => {
+        const repository = FirebaseArticleRepository(
+          firestore,
+          getOperations(),
+        );
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-03-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+
+        const article1 = Forger(ArticleMold).forgeWithSeed(320, { timeline: timeline1 });
+        const article2 = Forger(ArticleMold).forgeWithSeed(321, { timeline: timeline2 });
+
+        await repository.persist(article1).unwrap();
+        await repository.persist(article2).unwrap();
+
+        const criteria = createCriteria({ sortBy: "updatedAt", order: "desc" });
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(2);
+        expect(found[0]?.identifier).toBe(article1.identifier);
+        expect(found[1]?.identifier).toBe(article2.identifier);
       });
     });
 

--- a/applications/frontend/shared/tests/infrastructures/memos.test.ts
+++ b/applications/frontend/shared/tests/infrastructures/memos.test.ts
@@ -21,6 +21,7 @@ import { validateCriteria, type Criteria } from "@shared/domains/memo";
 import { PublishStatus } from "@shared/domains/common";
 import { TagIdentifierMold } from "../support/molds/domains/attributes/tag";
 import type { TagIdentifier } from "@shared/domains/attributes/tag";
+import { TimelineMold } from "../support/molds/domains/common/date";
 
 describe("infrastructures/memos", () => {
   let firestore: Firestore;
@@ -44,11 +45,15 @@ describe("infrastructures/memos", () => {
     tags?: TagIdentifier[] | null;
     freeWord?: string | null;
     status?: PublishStatus | null;
+    sortBy?: string | null;
+    order?: string | null;
   }): Criteria => {
     return validateCriteria({
       tags: params.tags ?? null,
       freeWord: params.freeWord ?? null,
       status: params.status ?? null,
+      sortBy: params.sortBy ?? null,
+      order: params.order ?? null,
     }).unwrap();
   };
 
@@ -374,6 +379,90 @@ describe("infrastructures/memos", () => {
 
         expect(found.length).toBe(1);
         expect(found[0]?.identifier).toBe(memo1.identifier);
+      });
+    });
+
+    describe("search ordering", () => {
+      it("デフォルトでcreatedAt降順で返る", async () => {
+        const repository = FirebaseMemoRepository(firestore, getOperations());
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-02-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+        const timeline3 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-03-01T00:00:00Z"),
+          updatedAt: new Date("2024-03-01T00:00:00Z"),
+        });
+
+        const memo1 = Forger(MemoMold).forgeWithSeed(400, { timeline: timeline1 });
+        const memo2 = Forger(MemoMold).forgeWithSeed(401, { timeline: timeline2 });
+        const memo3 = Forger(MemoMold).forgeWithSeed(402, { timeline: timeline3 });
+
+        await repository.persist(memo1).unwrap();
+        await repository.persist(memo2).unwrap();
+        await repository.persist(memo3).unwrap();
+
+        const criteria = createCriteria({});
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(3);
+        expect(found[0]?.identifier).toBe(memo3.identifier);
+        expect(found[1]?.identifier).toBe(memo2.identifier);
+        expect(found[2]?.identifier).toBe(memo1.identifier);
+      });
+
+      it("order: ascを指定すると昇順で返る", async () => {
+        const repository = FirebaseMemoRepository(firestore, getOperations());
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-02-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+
+        const memo1 = Forger(MemoMold).forgeWithSeed(410, { timeline: timeline1 });
+        const memo2 = Forger(MemoMold).forgeWithSeed(411, { timeline: timeline2 });
+
+        await repository.persist(memo1).unwrap();
+        await repository.persist(memo2).unwrap();
+
+        const criteria = createCriteria({ order: "asc" });
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(2);
+        expect(found[0]?.identifier).toBe(memo1.identifier);
+        expect(found[1]?.identifier).toBe(memo2.identifier);
+      });
+
+      it("sortBy: updatedAtを指定するとupdatedAt降順で返る", async () => {
+        const repository = FirebaseMemoRepository(firestore, getOperations());
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-03-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+
+        const memo1 = Forger(MemoMold).forgeWithSeed(420, { timeline: timeline1 });
+        const memo2 = Forger(MemoMold).forgeWithSeed(421, { timeline: timeline2 });
+
+        await repository.persist(memo1).unwrap();
+        await repository.persist(memo2).unwrap();
+
+        const criteria = createCriteria({ sortBy: "updatedAt", order: "desc" });
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(2);
+        expect(found[0]?.identifier).toBe(memo1.identifier);
+        expect(found[1]?.identifier).toBe(memo2.identifier);
       });
     });
 

--- a/applications/frontend/shared/tests/infrastructures/series.test.ts
+++ b/applications/frontend/shared/tests/infrastructures/series.test.ts
@@ -18,6 +18,7 @@ import {
 import type { FirestoreOperations } from "@shared/infrastructures/common";
 import { validateCriteria, type Criteria, type SeriesSlug } from "@shared/domains/series";
 import type { TagIdentifier } from "@shared/domains/attributes/tag";
+import { TimelineMold } from "../support/molds/domains/common/date";
 
 describe("infrastructures/series", () => {
   let firestore: Firestore;
@@ -36,12 +37,16 @@ describe("infrastructures/series", () => {
     tags?: TagIdentifier[] | null;
     status?: string | null;
     freeWord?: string | null;
+    sortBy?: string | null;
+    order?: string | null;
   }): Criteria => {
     return validateCriteria({
       slug: params.slug ?? null,
       tags: params.tags ?? null,
       status: params.status ?? null,
       freeWord: params.freeWord ?? null,
+      sortBy: params.sortBy ?? null,
+      order: params.order ?? null,
     }).unwrap();
   };
 
@@ -296,6 +301,90 @@ describe("infrastructures/series", () => {
         const found = await repository.search(criteria).unwrap();
 
         expect(found.length).toBe(0);
+      });
+    });
+
+    describe("search ordering", () => {
+      it("デフォルトでcreatedAt降順で返る", async () => {
+        const repository = FirebaseSeriesRepository(firestore, getOperations());
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-02-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+        const timeline3 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-03-01T00:00:00Z"),
+          updatedAt: new Date("2024-03-01T00:00:00Z"),
+        });
+
+        const series1 = Forger(SeriesMold).forgeWithSeed(500, { timeline: timeline1 });
+        const series2 = Forger(SeriesMold).forgeWithSeed(501, { timeline: timeline2 });
+        const series3 = Forger(SeriesMold).forgeWithSeed(502, { timeline: timeline3 });
+
+        await repository.persist(series1).unwrap();
+        await repository.persist(series2).unwrap();
+        await repository.persist(series3).unwrap();
+
+        const criteria = createCriteria({});
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(3);
+        expect(found[0]?.identifier).toBe(series3.identifier);
+        expect(found[1]?.identifier).toBe(series2.identifier);
+        expect(found[2]?.identifier).toBe(series1.identifier);
+      });
+
+      it("order: ascを指定すると昇順で返る", async () => {
+        const repository = FirebaseSeriesRepository(firestore, getOperations());
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-01-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-02-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+
+        const series1 = Forger(SeriesMold).forgeWithSeed(510, { timeline: timeline1 });
+        const series2 = Forger(SeriesMold).forgeWithSeed(511, { timeline: timeline2 });
+
+        await repository.persist(series1).unwrap();
+        await repository.persist(series2).unwrap();
+
+        const criteria = createCriteria({ order: "asc" });
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(2);
+        expect(found[0]?.identifier).toBe(series1.identifier);
+        expect(found[1]?.identifier).toBe(series2.identifier);
+      });
+
+      it("sortBy: updatedAtを指定するとupdatedAt降順で返る", async () => {
+        const repository = FirebaseSeriesRepository(firestore, getOperations());
+        const timeline1 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-03-01T00:00:00Z"),
+        });
+        const timeline2 = Forger(TimelineMold).forgeWithSeed(0, {
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+          updatedAt: new Date("2024-02-01T00:00:00Z"),
+        });
+
+        const series1 = Forger(SeriesMold).forgeWithSeed(520, { timeline: timeline1 });
+        const series2 = Forger(SeriesMold).forgeWithSeed(521, { timeline: timeline2 });
+
+        await repository.persist(series1).unwrap();
+        await repository.persist(series2).unwrap();
+
+        const criteria = createCriteria({ sortBy: "updatedAt", order: "desc" });
+        const found = await repository.search(criteria).unwrap();
+
+        expect(found.length).toBe(2);
+        expect(found[0]?.identifier).toBe(series1.identifier);
+        expect(found[1]?.identifier).toBe(series2.identifier);
       });
     });
 

--- a/applications/frontend/shared/tests/support/mock/firebase/firestore/query/query-engine.ts
+++ b/applications/frontend/shared/tests/support/mock/firebase/firestore/query/query-engine.ts
@@ -217,10 +217,31 @@ export class QueryEngine {
     return false
   }
 
+  private static isTimestamp(value: unknown): value is { seconds: number; nanoseconds: number; toDate: () => Date } {
+    return (
+      value !== null &&
+      typeof value === "object" &&
+      "seconds" in value &&
+      "nanoseconds" in value &&
+      "toDate" in value &&
+      typeof value.toDate === "function"
+    )
+  }
+
   private static compareValues(a: unknown, b: unknown): number {
     if (a == null && b == null) return 0
     if (a == null) return -1
     if (b == null) return 1
+
+    if (this.isTimestamp(a) && this.isTimestamp(b)) {
+      const diff = a.seconds - b.seconds
+      if (diff !== 0) return diff
+      return a.nanoseconds - b.nanoseconds
+    }
+
+    if (a instanceof Date && b instanceof Date) {
+      return a.getTime() - b.getTime()
+    }
 
     if (typeof a !== typeof b) {
       return typeof a < typeof b ? -1 : 1

--- a/applications/scripts/seed/article.ts
+++ b/applications/scripts/seed/article.ts
@@ -8,6 +8,7 @@ export async function seedArticles(): Promise<void> {
   console.log("\n--- Creating Articles ---");
 
   const now = new Date();
+  const oneDayMs = 24 * 60 * 60 * 1000;
 
   const articles = [
     {
@@ -49,6 +50,7 @@ function identity<T>(arg: T): T {
         "https://images.unsplash.com/photo-1516116216624-53e697fedbea?w=800",
       status: "published",
       tags: [TAG_IDS.typescript],
+      createdAt: new Date(now.getTime() - 5 * oneDayMs),
     },
     {
       id: ARTICLE_IDS.article2,
@@ -83,6 +85,7 @@ Reactでコンポーネントを設計する際の主要なパターンを紹介
         "https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=800",
       status: "published",
       tags: [TAG_IDS.react, TAG_IDS.typescript],
+      createdAt: new Date(now.getTime() - 4 * oneDayMs),
     },
     {
       id: ARTICLE_IDS.article3,
@@ -117,6 +120,7 @@ Next.js 13で導入されたApp Routerは、新しいルーティングシステ
         "https://images.unsplash.com/photo-1618477388954-7852f32655ec?w=800",
       status: "draft",
       tags: [TAG_IDS.nextjs, TAG_IDS.react, TAG_IDS.typescript],
+      createdAt: new Date(now.getTime() - 3 * oneDayMs),
     },
     {
       id: ARTICLE_IDS.article4,
@@ -159,6 +163,7 @@ Markdown記法を使えば、テキスト・画像・コードを組み合わせ
         "https://images.unsplash.com/photo-1461749280684-dccba630e2f6?w=800",
       status: "published",
       tags: [TAG_IDS.typescript, TAG_IDS.react],
+      createdAt: new Date(now.getTime() - 2 * oneDayMs),
     },
     {
       id: ARTICLE_IDS.article5,
@@ -195,6 +200,7 @@ Mermaid記法を使えば、テキストベースで図を管理できます。
         "https://images.unsplash.com/photo-1516116216624-53e697fedbea?w=800",
       status: "published",
       tags: [TAG_IDS.typescript],
+      createdAt: new Date(now.getTime() - 1 * oneDayMs),
     },
     {
       id: ARTICLE_IDS.article6,
@@ -352,6 +358,7 @@ gitGraph
         "https://images.unsplash.com/photo-1516116216624-53e697fedbea?w=800",
       status: "published",
       tags: [TAG_IDS.typescript],
+      createdAt: now,
     },
   ];
 
@@ -367,8 +374,8 @@ gitGraph
       tags: article.tags,
       images: [],
       timeline: {
-        createdAt: now,
-        updatedAt: now,
+        createdAt: article.createdAt,
+        updatedAt: article.createdAt,
       },
       version: 1,
     });

--- a/applications/scripts/seed/memo.ts
+++ b/applications/scripts/seed/memo.ts
@@ -8,7 +8,8 @@ export async function seedMemos(): Promise<void> {
   console.log("\n--- Creating Memos ---");
 
   const now = new Date();
-  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  const yesterday = new Date(now.getTime() - oneDayMs);
 
   const memos = [
     {
@@ -17,6 +18,7 @@ export async function seedMemos(): Promise<void> {
       slug: "go-tips",
       tags: [TAG_IDS.go],
       status: "published",
+      createdAt: now,
       entries: [
         {
           text: "Go言語ではエラーは値として扱う。`error`インターフェースを実装すれば独自エラー型を作れる。",
@@ -34,6 +36,7 @@ export async function seedMemos(): Promise<void> {
       slug: "typescript-config",
       tags: [TAG_IDS.typescript],
       status: "draft",
+      createdAt: yesterday,
       entries: [
         {
           text: "`strict: true`は必須。型安全性を最大限に活用するため。",
@@ -63,7 +66,7 @@ export async function seedMemos(): Promise<void> {
         images: [],
         entries: memo.entries,
         timeline: {
-          createdAt: yesterday,
+          createdAt: memo.createdAt,
           updatedAt: now,
         },
         version: 1,

--- a/applications/scripts/seed/series.ts
+++ b/applications/scripts/seed/series.ts
@@ -219,7 +219,15 @@ export async function seedSeries(): Promise<void> {
 
   console.log("\n--- Creating Series ---");
 
+  const oneDayMs = 24 * 60 * 60 * 1000;
+  const seriesCreatedAts: Record<string, Date> = {
+    [SERIES_IDS.series1]: new Date(now.getTime() - 2 * oneDayMs),
+    [SERIES_IDS.series2]: new Date(now.getTime() - 1 * oneDayMs),
+    [SERIES_IDS.series3]: now,
+  };
+
   for (const series of SERIES_DATA_INTERNAL) {
+    const seriesCreatedAt = seriesCreatedAts[series.id] ?? now;
     await createDocument(
       "series",
       series.id,
@@ -234,8 +242,8 @@ export async function seedSeries(): Promise<void> {
         chapters: series.chapters,
         status: series.status,
         timeline: {
-          createdAt: now,
-          updatedAt: now,
+          createdAt: seriesCreatedAt,
+          updatedAt: seriesCreatedAt,
         },
         version: 1,
       },


### PR DESCRIPTION
## Summary

Issue #37 の対応。

- Criteria に `sortBy` (createdAt / updatedAt) と `order` (asc / desc) フィールドを追加
- articles / memo / series の Firestore クエリに `orderBy("timeline.createdAt", "desc")` をデフォルト適用し、新しい順でコンテンツを返す
- 対象ドメイン: articles / memo / series（infrastructure 層の search メソッド）
- シードデータの `createdAt` を 1 日ずつずらして順序を明確化
- トップページ・記事一覧・メモ一覧・シリーズ一覧の新しい順表示を検証する E2E テストを 22 件追加

## 検証結果

| 検証項目 | 結果 |
|---------|------|
| `pnpm lint` | PASS |
| `pnpm typecheck` (shared / reader / admin) | PASS |
| `pnpm test --run --passWithNoTests` (unit) | 2346 passed |
| infra テスト | 9 件追加・全グリーン |
| E2E テスト（playwright --list） | 追加 22 件含む全テスト検出済み |

> 既存の 3 件の失敗は `main` にも存在する既存バグであり、本実装とは無関係

## 重要な注意事項（本番デプロイ時）

Firestore コンポジットインデックスが必要になる可能性があります。

特に `tags array-contains-any` と `orderBy(timeline.createdAt, desc)` の組み合わせはコンポジットインデックスが必須です。

- 初回クエリ実行時に Firestore Console でインデックス作成 URL が表示されるので順次作成する
- または別 Issue で `firestore.indexes.json` の整備を推奨

## Checklist

- [x] Frontend
- [ ] Backend
- [ ] Infrastructure
- [ ] Design