### PR TITLE
refactor(frontend): コードブロックのフォントサイズを調整する

### DIFF
--- a/applications/frontend/shared/src/components/global/mdx.module.css
+++ b/applications/frontend/shared/src/components/global/mdx.module.css
@@ -26,7 +26,7 @@
   overflow-x: auto;
   font-family:
     "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", var(--font-mono);
-  font-size: 0.875rem;
+  font-size: 1rem;
   line-height: 1.4;
   background-color: #24292e;
   border: none;
@@ -42,7 +42,7 @@
 @media (max-width: 768px) {
   .pre {
     padding: 0.75rem 1rem;
-    font-size: 0.8125rem;
+    font-size: 0.875rem;
     line-height: 1.4;
   }
 }

--- a/applications/frontend/shared/tests/components/global/mdx-styles.test.ts
+++ b/applications/frontend/shared/tests/components/global/mdx-styles.test.ts
@@ -58,4 +58,19 @@ describe("components/global/mdx.module.css", () => {
     const preSection = css.slice(preStart, css.indexOf("}", preStart) + 1);
     expect(preSection).toMatch(/padding/);
   });
+
+  it(".pre の PC 時 font-size が 1rem (16px)", () => {
+    const preStart = css.indexOf(".pre {");
+    const preSection = css.slice(preStart, css.indexOf("}", preStart) + 1);
+    expect(preSection).toContain("font-size: 1rem");
+  });
+
+  it(".pre の SP 時 font-size が 0.875rem (14px)", () => {
+    const mediaStart = css.indexOf("@media (max-width: 768px)");
+    const mediaSection = css.slice(mediaStart);
+    const preStart = mediaSection.indexOf(".pre {");
+    const preEnd = mediaSection.indexOf("}", preStart) + 1;
+    const preSection = mediaSection.slice(preStart, preEnd);
+    expect(preSection).toContain("font-size: 0.875rem");
+  });
 });


### PR DESCRIPTION
## Summary

- 記事詳細・メモ詳細・チャプター詳細の MDX レンダラ内のコードブロック (`pre`) の font-size を可読性向上のために調整
- PC サイズ (>768px): 16px (1rem)
- SP サイズ (≤768px): 14px (0.875rem)

## 変更対象

- `applications/frontend/shared/src/components/global/mdx.module.css` (`.pre` 内の `font-size`)

## Test plan

- [ ] `pnpm lint` が通る
- [ ] `pnpm tsc --noEmit` が通る
- [ ] `pnpm test --run --passWithNoTests` が通る
- [ ] 記事詳細・メモ詳細・チャプター詳細ページでコードブロックが想定サイズで描画される（スクリーンショット）