### PR TITLE
chore(ci): ci/e2e workflow に最小権限 permissions を明示する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, staging]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, staging]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## 概要
リポジトリ全体の `default_workflow_permissions` を `read` に維持しつつ、release-please のような PR 作成 workflow を動かせるようにするため、`ci.yml` / `e2e.yml` に明示的な `permissions: contents: read` を追加する。

## 背景
PR #36 マージ後に release-please workflow が「Actions が PR を作成できない」エラーで失敗。設定確認したところ:
- `can_approve_pull_request_reviews: false` → `true` (必要)
- `default_workflow_permissions: read` → `write` (一時的に変更したが過剰)

`default_workflow_permissions: write` にすると、permissions 未指定の workflow (`ci.yml`, `e2e.yml`) が **write 権限を持つ** ことになり最小権限原則に反する。本 PR で両 workflow に明示的に `contents: read` を追加することで、`default_workflow_permissions: read` を維持しつつ release-please も動作する状態にする。

## 変更内容
- `.github/workflows/ci.yml`: `permissions: contents: read` を追加
- `.github/workflows/e2e.yml`: `permissions: contents: read` を追加

## リポジトリ設定 (本 PR とは別に gh api で実施済み)
\`\`\`
default_workflow_permissions: read   # 維持
can_approve_pull_request_reviews: true   # release-please に必要
\`\`\`

## Test plan
- [x] actionlint で両 workflow が clean
- [ ] CI / E2E がこの PR でも pass する