### PR TITLE
chore(ci): staging → main: workflow permissions の最小化を本番に反映する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, staging]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, staging]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## 概要
PR #41 (`chore/workflow-permissions-hardening`) を staging にマージ済み。staging から main へ反映する。

## 含まれる変更
- ad0e1d2 chore(ci): ci.yml と e2e.yml に最小権限の permissions を明示する

## 背景
リポジトリ設定の `default_workflow_permissions` を `read` に維持しつつ、`ci.yml` と `e2e.yml` に明示的な `permissions: contents: read` を追加し、最小権限原則を満たす。

## マージ後の挙動
- main push トリガーで release-please workflow が再走し、PR #40 (chore: release 0.2.0) を更新する
- `releases_created=false` のまま (Release PR がマージされていないため) deploy-admin-prd は走らない

## Test plan
- [x] PR #41 で CI / Build / E2E (一部) が pass 済み
- [ ] staging → main PR でも CI / E2E が pass する