### PR TITLE
chore(ci): staging から main への同期 PR を自動作成する workflow を追加

### DIFF
--- a/.github/workflows/sync-staging-to-main.yml
+++ b/.github/workflows/sync-staging-to-main.yml
@@ -1,0 +1,66 @@
+name: Sync staging to main
+
+on:
+  push:
+    branches: [staging]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: sync-staging-to-main
+  cancel-in-progress: false
+
+jobs:
+  create-pr:
+    name: Create or update staging→main PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Create or update PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          existing=$(gh pr list --base main --head staging --state open --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            echo "PR #${existing} already exists. Updating body."
+            gh pr edit "${existing}" --body "$(cat <<'BODY'
+          ## 概要
+          `staging` ブランチを `main` に同期する自動生成 PR。
+
+          ## マージ前確認事項
+          - [ ] CI / E2E が pass している
+          - [ ] 含まれる commit を確認
+          - [ ] release-please workflow が走るタイミングを意識する
+
+          ---
+          このPRは `Sync staging to main` workflow が staging への push 時に自動生成・更新する。
+          BODY
+          )"
+          else
+            echo "Creating new staging→main PR"
+            gh pr create \
+              --base main \
+              --head staging \
+              --title "chore: sync staging to main" \
+              --body "$(cat <<'BODY'
+          ## 概要
+          `staging` ブランチを `main` に同期する自動生成 PR。
+
+          ## マージ前確認事項
+          - [ ] CI / E2E が pass している
+          - [ ] 含まれる commit を確認
+          - [ ] release-please workflow が走るタイミングを意識する
+
+          ---
+          このPRは `Sync staging to main` workflow が staging への push 時に自動生成・更新する。
+          BODY
+          )"
+          fi

--- a/.github/workflows/sync-staging-to-main.yml
+++ b/.github/workflows/sync-staging-to-main.yml
@@ -28,10 +28,14 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          existing=$(gh pr list --base main --head staging --state open --json number --jq '.[0].number // empty')
-          if [ -n "${existing}" ]; then
-            echo "PR #${existing} already exists. Updating body."
-            gh pr edit "${existing}" --body "$(cat <<'BODY'
+
+          ahead=$(git rev-list --count origin/main..origin/staging)
+          if [ "${ahead}" -eq 0 ]; then
+            echo "staging has no new commits ahead of main. Skipping PR creation."
+            exit 0
+          fi
+
+          body=$(cat <<'BODY'
           ## 概要
           `staging` ブランチを `main` に同期する自動生成 PR。
 
@@ -43,24 +47,17 @@ jobs:
           ---
           このPRは `Sync staging to main` workflow が staging への push 時に自動生成・更新する。
           BODY
-          )"
+          )
+
+          existing=$(gh pr list --base main --head staging --state open --json number --jq '.[0].number // empty')
+          if [ -n "${existing}" ]; then
+            echo "PR #${existing} already exists. Updating body."
+            gh pr edit "${existing}" --body "${body}"
           else
             echo "Creating new staging→main PR"
             gh pr create \
               --base main \
               --head staging \
               --title "chore: sync staging to main" \
-              --body "$(cat <<'BODY'
-          ## 概要
-          `staging` ブランチを `main` に同期する自動生成 PR。
-
-          ## マージ前確認事項
-          - [ ] CI / E2E が pass している
-          - [ ] 含まれる commit を確認
-          - [ ] release-please workflow が走るタイミングを意識する
-
-          ---
-          このPRは `Sync staging to main` workflow が staging への push 時に自動生成・更新する。
-          BODY
-          )"
+              --body "${body}"
           fi


### PR DESCRIPTION
## 概要
`staging` ブランチへの push 時に、自動で `staging → main` の PR を起票・更新する workflow を追加する。

## 動機
現状、機能を staging にマージした後、`staging → main` の PR を**手動**で作成する必要がある。これを workflow で自動化し、staging に変更がある限り常に最新の同期 PR が存在する状態にする。

## 動作
- Trigger: `push: branches: [staging]` または `workflow_dispatch`
- 既存の `staging → main` PR があれば body を更新
- 無ければ新規作成

## 既知の制約
GitHub の仕様で `GITHUB_TOKEN` で作成された PR では他の workflow がトリガーされない。本 workflow も GITHUB_TOKEN を fallback で使うため、自動生成された PR では CI/E2E が走らない。

これを解決するには `RELEASE_PLEASE_TOKEN` という名前の Personal Access Token (or GitHub App token) を Repository Secret に登録する必要がある。secret があれば自動的にそちらが優先される（fallback ロジック実装済）。

→ token 準備は別 issue にて対応推奨。

## Test plan
- [x] actionlint で clean
- [ ] staging にマージ後、staging への次の push で自動起動することを確認