### PR TITLE
fix(ci): sync-staging-to-main 自動 PR 本文に PR タイトル一覧を表示する

### DIFF
--- a/.github/workflows/sync-staging-to-main.yml
+++ b/.github/workflows/sync-staging-to-main.yml
@@ -35,18 +35,37 @@ jobs:
             exit 0
           fi
 
-          body=$(cat <<'BODY'
+          pr_numbers=$(git log origin/main..origin/staging --merges --reverse --pretty=format:'%s' \
+            | grep -oE 'Merge pull request #[0-9]+' \
+            | grep -oE '[0-9]+' || true)
+          prs=""
+          pr_count=0
+          for num in ${pr_numbers}; do
+            title=$(gh pr view "${num}" --json title --jq .title 2>/dev/null || echo "(取得失敗)")
+            prs+="- #${num}: ${title}"$'\n'
+            pr_count=$((pr_count + 1))
+          done
+          if [ -z "${prs}" ]; then
+            prs="(該当 PR なし)"
+          else
+            prs=${prs%$'\n'}
+          fi
+
+          body=$(cat <<EOF
           ## 概要
-          `staging` ブランチを `main` に同期する自動生成 PR。
+          \`staging\` ブランチを \`main\` に同期する自動生成 PR。
+
+          ## 含まれる PR (${pr_count} 件 / ahead ${ahead})
+
+          ${prs}
 
           ## マージ前確認事項
           - [ ] CI / E2E が pass している
-          - [ ] 含まれる commit を確認
           - [ ] release-please workflow が走るタイミングを意識する
 
           ---
-          このPRは `Sync staging to main` workflow が staging への push 時に自動生成・更新する。
-          BODY
+          この PR は \`Sync staging to main\` workflow が staging への push 時に自動生成・更新する。
+          EOF
           )
 
           existing=$(gh pr list --base main --head staging --state open --json number --jq '.[0].number // empty')


### PR DESCRIPTION
## 概要
`Sync staging to main` workflow が自動生成する PR の本文に「含まれる PR の一覧」が無く、レビュー時に中身が分からない問題に対応する。

## 変更内容
- merge commit のメッセージから PR 番号を抽出 (`grep -oE 'Merge pull request #[0-9]+'`)
- 各 PR 番号で `gh pr view --json title --jq .title` を呼び、タイトルを取得
- 件数 (`pr_count`) と ahead 数を併記
- PR が無い (= マージコミット 0 件) の場合は "(該当 PR なし)" と表示

## 出力例
```
## 概要
`staging` ブランチを `main` に同期する自動生成 PR。

## 含まれる PR (1 件 / ahead 3)

- #43: chore(ci): staging から main への同期 PR を自動作成する workflow を追加

## マージ前確認事項
- [ ] CI / E2E が pass している
- [ ] release-please workflow が走るタイミングを意識する
```

## Test plan
- [x] actionlint clean
- [x] actrun lint clean
- [x] actrun dry-run parse OK
- [x] ローカル bash heredoc 動作確認（変数展開・Markdown ヘディング・バッククォート すべて期待通り）
- [x] PR タイトル抽出ロジックを実データで動作確認 (`#43` のタイトルが取得できた)
- [ ] PR マージ後、次回 staging push で生成される PR 本文に PR 一覧が出る