### PR TITLE
fix(infra): Firestore複合インデックスを追加してビルド失敗を解消

### DIFF
--- a/infrastructure/environments/prd/main.tf
+++ b/infrastructure/environments/prd/main.tf
@@ -90,6 +90,33 @@ module "firestore" {
   enable_daily_backup = true
   backup_retention    = "604800s"
   rules_file          = "${path.module}/../../../firestore.rules"
+
+  composite_indexes = [
+    {
+      name       = "articles-status-created-at"
+      collection = "articles"
+      fields = [
+        { field_path = "status", order = "ASCENDING" },
+        { field_path = "timeline.createdAt", order = "DESCENDING" },
+      ]
+    },
+    {
+      name       = "memos-status-created-at"
+      collection = "memos"
+      fields = [
+        { field_path = "status", order = "ASCENDING" },
+        { field_path = "timeline.createdAt", order = "DESCENDING" },
+      ]
+    },
+    {
+      name       = "series-status-created-at"
+      collection = "series"
+      fields = [
+        { field_path = "status", order = "ASCENDING" },
+        { field_path = "timeline.createdAt", order = "DESCENDING" },
+      ]
+    },
+  ]
 }
 
 module "identity_platform" {

--- a/infrastructure/environments/stg/main.tf
+++ b/infrastructure/environments/stg/main.tf
@@ -75,6 +75,33 @@ module "firestore" {
   location_id   = var.firestore_location
   database_name = "(default)"
   rules_file    = "${path.module}/../../../firestore.rules"
+
+  composite_indexes = [
+    {
+      name       = "articles-status-created-at"
+      collection = "articles"
+      fields = [
+        { field_path = "status", order = "ASCENDING" },
+        { field_path = "timeline.createdAt", order = "DESCENDING" },
+      ]
+    },
+    {
+      name       = "memos-status-created-at"
+      collection = "memos"
+      fields = [
+        { field_path = "status", order = "ASCENDING" },
+        { field_path = "timeline.createdAt", order = "DESCENDING" },
+      ]
+    },
+    {
+      name       = "series-status-created-at"
+      collection = "series"
+      fields = [
+        { field_path = "status", order = "ASCENDING" },
+        { field_path = "timeline.createdAt", order = "DESCENDING" },
+      ]
+    },
+  ]
 }
 
 module "identity_platform" {

--- a/infrastructure/modules/firestore/README.md
+++ b/infrastructure/modules/firestore/README.md
@@ -18,6 +18,17 @@ module "firestore" {
   delete_protection   = true
   enable_daily_backup = true
   backup_retention    = "604800s"
+
+  composite_indexes = [
+    {
+      name       = "articles-status-created-at"
+      collection = "articles"
+      fields = [
+        { field_path = "status", order = "ASCENDING" },
+        { field_path = "timeline.createdAt", order = "DESCENDING" },
+      ]
+    },
+  ]
 }
 ```
 
@@ -31,6 +42,8 @@ module "firestore" {
 | delete_protection | Whether to enable delete protection on the database | `bool` | `false` | no |
 | enable_daily_backup | Whether to enable daily automatic backup of the Firestore database | `bool` | `false` | no |
 | backup_retention | Retention period for Firestore backups in duration format (e.g. 604800s for 7 days) | `string` | `"604800s"` | no |
+| rules_file | Path to the Firestore security rules file | `string` | `null` | no |
+| composite_indexes | Composite indexes to create on the Firestore database | `list(object)` | `[]` | no |
 
 ## Outputs
 

--- a/infrastructure/modules/firestore/main.tf
+++ b/infrastructure/modules/firestore/main.tf
@@ -36,3 +36,20 @@ resource "google_firestore_backup_schedule" "daily" {
 
   daily_recurrence {}
 }
+
+resource "google_firestore_index" "composite" {
+  for_each = { for index in var.composite_indexes : index.name => index }
+
+  project     = var.project_id
+  database    = google_firestore_database.this.name
+  collection  = each.value.collection
+  query_scope = each.value.query_scope
+
+  dynamic "fields" {
+    for_each = each.value.fields
+    content {
+      field_path = fields.value.field_path
+      order      = fields.value.order
+    }
+  }
+}

--- a/infrastructure/modules/firestore/variables.tf
+++ b/infrastructure/modules/firestore/variables.tf
@@ -37,3 +37,17 @@ variable "rules_file" {
   type        = string
   default     = null
 }
+
+variable "composite_indexes" {
+  description = "Composite indexes to create on the Firestore database"
+  type = list(object({
+    name        = string
+    collection  = string
+    query_scope = optional(string, "COLLECTION")
+    fields = list(object({
+      field_path = string
+      order      = optional(string)
+    }))
+  }))
+  default = []
+}


### PR DESCRIPTION
## Summary
- PR #38 で `orderBy("timeline.createdAt", "desc")` が追加された結果、`where("status", "==", ...) + orderBy` の複合クエリになり、staging デプロイの Docker ビルド（generateStaticParams → searchAllSlugs）が `FAILED_PRECONDITION: The query requires an index` で失敗。
- Terraform `firestore` モジュールに `google_firestore_index` を追加し、articles / memos / series 用の複合インデックスを宣言的に管理する。
- stg / prd 両環境で必要なインデックスを注入する。

## Test plan
- [ ] `terraform fmt` / `terraform validate` (stg / prd)
- [ ] staging で `terraform apply`
- [ ] staging の Cloud Run デプロイが成功することを確認