### PR TITLE
fix(frontend): ContentEmpty の「コンテンツが公開されるとここに表示されます」文言を削除

### DIFF
--- a/applications/frontend/shared/src/components/molecules/empty/content.tsx
+++ b/applications/frontend/shared/src/components/molecules/empty/content.tsx
@@ -2,7 +2,7 @@ import styles from "./content.module.css";
 
 export type Props = {
   title: string;
-  description: string;
+  description?: string;
   icon?: React.ReactNode;
 };
 
@@ -10,6 +10,8 @@ export const ContentEmpty = (props: Props) => (
   <div className={styles.container}>
     {props.icon && <div className={styles.icon}>{props.icon}</div>}
     <h3 className={styles.title}>{props.title}</h3>
-    <p className={styles.description}>{props.description}</p>
+    {props.description && (
+      <p className={styles.description}>{props.description}</p>
+    )}
   </div>
 );

--- a/applications/frontend/shared/src/components/organisms/common/top/search.presenter.tsx
+++ b/applications/frontend/shared/src/components/organisms/common/top/search.presenter.tsx
@@ -57,7 +57,6 @@ export const ContentSectionPresenter = (props: Props) => {
         </div>
         <ContentEmpty
           title="まだコンテンツがありません"
-          description="コンテンツが公開されるとここに表示されます"
           icon={emptyIconFor(props.type)}
         />
       </section>

--- a/applications/frontend/shared/tests/components/molecules/empty/content.test.tsx
+++ b/applications/frontend/shared/tests/components/molecules/empty/content.test.tsx
@@ -7,15 +7,31 @@ import { ContentEmpty } from "@shared/components/molecules/empty/content";
 
 describe("components/molecules/empty/ContentEmpty", () => {
   describe("デフォルト表示", () => {
-    it("タイトルと説明文が表示される", () => {
-      render(
-        <ContentEmpty title="記事がありません" description="記事が公開されるとここに表示されます" />
-      );
+    it("タイトルが常に表示される", () => {
+      render(<ContentEmpty title="記事がありません" />);
 
       expect(screen.getByText("記事がありません")).toBeInTheDocument();
+    });
+
+    it("descriptionが渡された場合、説明文が表示される", () => {
+      render(
+        <ContentEmpty
+          title="記事がありません"
+          description="記事が公開されるとここに表示されます"
+        />
+      );
+
       expect(
         screen.getByText("記事が公開されるとここに表示されます")
       ).toBeInTheDocument();
+    });
+
+    it("descriptionが渡されない場合、説明文の要素は描画されない", () => {
+      const { container } = render(
+        <ContentEmpty title="記事がありません" />
+      );
+
+      expect(container.querySelector("p")).toBeNull();
     });
   });
 
@@ -45,8 +61,11 @@ describe("components/molecules/empty/ContentEmpty", () => {
         <ContentEmpty title="テスト" description="説明" />
       );
 
-      const className = (container.firstChild as HTMLElement).className;
-      expect(className).toMatch(/container/);
+      const firstChild = container.firstChild;
+      if (!(firstChild instanceof HTMLElement)) {
+        throw new Error("firstChild is not an HTMLElement");
+      }
+      expect(firstChild.className).toMatch(/container/);
     });
   });
 });

--- a/applications/frontend/shared/tests/components/organisms/common/top/search-presenter.test.tsx
+++ b/applications/frontend/shared/tests/components/organisms/common/top/search-presenter.test.tsx
@@ -26,12 +26,12 @@ describe("components/organisms/common/top/ContentSectionPresenter", () => {
       ).toBeInTheDocument();
     });
 
-    it("コンテンツが0件の場合、説明文が表示される", () => {
+    it("コンテンツが0件の場合、廃止された説明文は表示されない", () => {
       render(<ContentSectionPresenter {...createProps()} />);
 
       expect(
-        screen.getByText("コンテンツが公開されるとここに表示されます")
-      ).toBeInTheDocument();
+        screen.queryByText(/コンテンツが公開される/)
+      ).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- `ContentEmpty` コンポーネントを使用している箇所から「コンテンツが公開されるとここに表示されます」という文言を削除する

## Checklist
- [ ] Frontend
- [ ] Backend
- [ ] Infrastructure
- [ ] Design