### PR TITLE
chore(ci): split terraform-ci plan into dedicated plan environments

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: terraform fmt -check -recursive
 
   plan:
-    name: Terraform plan (${{ matrix.environment }})
+    name: Terraform plan (${{ matrix.name }})
     needs: fmt
     runs-on: ubuntu-latest
     permissions:
@@ -46,11 +46,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [stg, prd]
-    environment: ${{ matrix.environment }}
+        include:
+          - name: stg
+            plan_env: stg-plan
+          - name: prd
+            plan_env: prd-plan
+    # plan_env は PR トリガで参照するため deployment_branch_policy を
+    # 付けない plan 専用環境 (stg-plan / prd-plan)。
+    # deploy/migrate 用の stg / prd 環境は main/staging のみ許可される。
+    environment: ${{ matrix.plan_env }}
     defaults:
       run:
-        working-directory: infrastructure/environments/${{ matrix.environment }}
+        working-directory: infrastructure/environments/${{ matrix.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -140,7 +147,7 @@ jobs:
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          MATRIX_ENV: ${{ matrix.environment }}
+          MATRIX_ENV: ${{ matrix.name }}
           PLAN_TEXT: ${{ steps.plan-output.outputs.plan }}
           PLAN_STATUS: ${{ job.status }}
         with:

--- a/scripts/create-plan-environments.sh
+++ b/scripts/create-plan-environments.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# create-plan-environments.sh
+#
+# Terraform CI plan job 専用の GitHub Environment (stg-plan / prd-plan) を作成し、
+# 既存の stg / prd environment から 6 個の必須 secret をコピーするための対話スクリプト。
+#
+# 背景:
+#   terraform-ci.yml の plan job は PR トリガで environment を参照しているため、
+#   既存 stg / prd environment に deployment_branch_policy を設定すると
+#   feature branch の PR で CI が壊れる。
+#
+#   対策として plan 専用環境 (stg-plan / prd-plan) を作成し、
+#   terraform-ci.yml はそちらを参照、既存 stg / prd は deploy/migrate 専用として
+#   deployment_branch_policy (main/staging 限定) を適用する。
+#
+# 前提:
+#   - gh CLI 認証済み (gh auth status)
+#   - 既存 stg / prd environment の 6 secret の値を手元に用意していること
+#     (GitHub API では secret の値を取得できないため)
+#
+# 使い方:
+#   bash scripts/create-plan-environments.sh
+#
+# 実行すると:
+#   1. stg-plan / prd-plan environment を作成
+#   2. 各 plan 環境に 6 secret をコピー (対話入力)
+#   3. 最後に作成された secret 名の一覧を表示して検証
+#
+
+set -euo pipefail
+
+REPO="lihs-ie/hut"
+SOURCE_ENVS=("stg" "prd")
+PLAN_ENVS=("stg-plan" "prd-plan")
+
+# terraform-ci.yml の plan job が参照する 6 個の secret のみコピー
+# Firebase 系 / SERVER_ACTIONS_ALLOWED_ORIGINS は deploy.yml 専用なので除外
+SECRET_NAMES=(
+  "GCP_PROJECT_ID"
+  "GCP_SERVICE_ACCOUNT_EMAIL"
+  "GCP_WORKLOAD_IDENTITY_PROVIDER"
+  "TF_VAR_AUTHORIZED_MEMBERS"
+  "TF_VAR_OAUTH_CLIENT_ID"
+  "TF_VAR_OAUTH_CLIENT_SECRET"
+)
+
+echo "=== GitHub CLI auth check ==="
+gh auth status
+echo ""
+
+echo "=== 1. Create plan-only environments ==="
+for ENV in "${PLAN_ENVS[@]}"; do
+  echo "Creating/updating environment: ${ENV}"
+  gh api -X PUT "repos/${REPO}/environments/${ENV}" >/dev/null
+  echo "  -> ok"
+done
+echo ""
+
+echo "=== 2. Copy secrets into plan environments ==="
+echo "You will be prompted 12 times in total (6 secrets x 2 environments)."
+echo "Paste the existing secret value from stg/prd when asked."
+echo "Tip: gh secret set reads the value from stdin; press Enter after pasting and Ctrl-D to finalize."
+echo ""
+
+for i in 0 1; do
+  SRC="${SOURCE_ENVS[$i]}"
+  DST="${PLAN_ENVS[$i]}"
+  echo "--- Source: ${SRC} -> Destination: ${DST} ---"
+  for NAME in "${SECRET_NAMES[@]}"; do
+    echo ""
+    echo "Enter value for ${NAME} (from ${SRC}):"
+    gh secret set "${NAME}" --env "${DST}" --repo "${REPO}"
+  done
+  echo ""
+done
+
+echo ""
+echo "=== 3. Verification ==="
+for ENV in "${PLAN_ENVS[@]}"; do
+  echo "Secrets in ${ENV}:"
+  gh api "repos/${REPO}/environments/${ENV}/secrets" --jq '.secrets[].name' | sed 's/^/  - /'
+done
+
+echo ""
+echo "=== Done ==="
+echo ""
+echo "Next steps:"
+echo "  1. Merge PR that switches terraform-ci.yml matrix to stg-plan / prd-plan."
+echo "  2. Apply deployment_branch_policy on the existing stg / prd environments"
+echo "     (prd -> main only, stg -> staging only)."
+echo "     This is handled by Claude post-merge."


### PR DESCRIPTION
## 概要
`terraform-ci.yml` の plan job を **plan 専用環境** (`stg-plan` / `prd-plan`) に向け、既存 `stg` / `prd` 環境には `deployment_branch_policy` を適用できるようにする準備 PR。

### なぜ必要か
PR #57 のセキュリティハードニング調査で、`prd` / `stg` 環境に `deployment_branch_policy` (main/staging のみ許可) を設定したいが、`terraform-ci.yml` の plan job が **PR トリガで `environment: ${{ matrix.environment }}`** を参照しているため、branch 制限を入れると feature branch の PR で CI が壊れる問題が判明。

plan 専用環境を別途作成し、terraform-ci.yml はそちらを経由して secrets を取得する構成に刷新することで両立する。

## 変更内容

### 1. `.github/workflows/terraform-ci.yml`
matrix を `include` 構造に変更し、`plan_env` フィールドで環境名のみ分離:

```yaml
strategy:
  matrix:
    include:
      - name: stg
        plan_env: stg-plan
      - name: prd
        plan_env: prd-plan
environment: ${{ matrix.plan_env }}
defaults:
  run:
    working-directory: infrastructure/environments/${{ matrix.name }}
```

**維持されるもの**:
- status check 名: `Terraform plan (stg)` / `Terraform plan (prd)`（`matrix.name` 参照）
- working-directory: `infrastructure/environments/{stg,prd}`
- PR コメントマーカー: `<!-- terraform-plan:stg -->` / `<!-- terraform-plan:prd -->`

**変更されるもの**:
- GitHub environment の参照先: `stg` / `prd` → `stg-plan` / `prd-plan`

### 2. `scripts/create-plan-environments.sh` (新規)
`stg-plan` / `prd-plan` 環境を `gh api` で作成し、`terraform-ci.yml` の plan job が必要とする 6 個の secrets を既存環境からコピーする対話スクリプト。

コピー対象（plan job で参照される secrets のみ、Firebase 系は含まない）:
```
GCP_PROJECT_ID
GCP_SERVICE_ACCOUNT_EMAIL
GCP_WORKLOAD_IDENTITY_PROVIDER
TF_VAR_AUTHORIZED_MEMBERS
TF_VAR_OAUTH_CLIENT_ID
TF_VAR_OAUTH_CLIENT_SECRET
```

## マージ前に必要な作業（ユーザー実施）

GitHub API では secret の値を取得できないため、**既存 `stg` / `prd` の 6 個の secret 値**を password manager 等から取り出して、以下のスクリプトに対話入力する必要があります:

```bash
bash scripts/create-plan-environments.sh
```

スクリプトは 12 回入力を求めます（6 secrets × 2 環境）。

### スクリプト実行後の確認
```bash
gh api repos/lihs-ie/hut/environments/stg-plan/secrets --jq '.secrets[].name'
gh api repos/lihs-ie/hut/environments/prd-plan/secrets --jq '.secrets[].name'
```
期待: 6 個の secret 名が出力される。

**この作業が完了しないまま PR をマージすると、次の terraform-ci.yml 実行時に plan job が Workload Identity 認証で失敗するので注意**。

## ポストマージ作業（Claude 実施）

マージ後に既存 `stg` / `prd` 環境へ `deployment_branch_policy` を適用:

```bash
# prd: main のみデプロイ可
gh api -X PATCH repos/lihs-ie/hut/environments/prd --input - <<'EOF'
{
  "deployment_branch_policy": {
    "protected_branches": false,
    "custom_branch_policies": true
  }
}
EOF
gh api -X POST repos/lihs-ie/hut/environments/prd/deployment-branch-policies -f name=main

# stg: staging のみデプロイ可
gh api -X PATCH repos/lihs-ie/hut/environments/stg --input - <<'EOF'
{
  "deployment_branch_policy": {
    "protected_branches": false,
    "custom_branch_policies": true
  }
}
EOF
gh api -X POST repos/lihs-ie/hut/environments/stg/deployment-branch-policies -f name=staging
```

これで以下が保証される:
- `deploy.yml` (workflow_dispatch) は main/staging からのみ起動可能
- `migrate.yml` (workflow_dispatch) も同様
- `release-please.yml` → `deploy.yml (prd)` は main push から呼ばれるので動作継続
- `terraform-ci.yml` の plan は `stg-plan` / `prd-plan` を経由するので無影響

## Test plan
- [ ] `bash scripts/create-plan-environments.sh` をユーザーが実行し、12 個の secret を設定
- [ ] `gh api repos/lihs-ie/hut/environments/{stg,prd}-plan/secrets --jq '.secrets[].name'` で 6 個の secret が配置されていることを確認
- [ ] この PR の CI で `Terraform plan (stg)` / `Terraform plan (prd)` がグリーン
- [ ] マージ後、Claude が既存 `stg` / `prd` に `deployment_branch_policy` を適用
- [ ] 次の infrastructure 変更 PR で terraform-ci.yml が plan 専用環境を経由して plan を実行できることを確認
- [ ] feature branch から `deploy.yml` の `workflow_dispatch` を試み、branch policy でブロックされることを確認

## 関連
- 先行 PR: #57 (セキュリティハードニングの主要項目)
- 計画書: ローカル `.claude/plans/tingly-juggling-fox.md`
