### PR TITLE
chore(ci): drop redundant push triggers from CI and E2E workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main, staging]
-  push:
-    branches: [main, staging]
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,6 @@ name: E2E Tests
 on:
   pull_request:
     branches: [main, staging]
-  push:
-    branches: [main, staging]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 概要
main / staging への push / pull_request の両方に設定されていた CI / E2E トリガを pull_request のみに絞る。PR マージ時の 2 重実行を解消する。

## 背景
\`.github/workflows/ci.yml\` と \`.github/workflows/e2e.yml\` は以下の設定になっており、マージ時に同じコミットで 2 回 workflow が走っていた:

\`\`\`yaml
on:
  pull_request:
    branches: [main, staging]
  push:
    branches: [main, staging]
\`\`\`

発火の流れ:
1. feature branch → staging の PR で \`pull_request\` トリガ → 1 回目
2. PR マージ後、staging への push で \`push\` トリガ → 2 回目（同じコミット内容）

\`pull_request\` トリガは base と head を仮マージした状態で実行されるので、1 回目で既にマージ後の状態を検証済み。2 回目の \`push\` トリガは冗長。

## 変更内容
- \`.github/workflows/ci.yml\`: \`push\` トリガを削除
- \`.github/workflows/e2e.yml\`: \`push\` トリガを削除（\`workflow_dispatch\` は残存）

## 影響
- CI / E2E の実行回数が半減（PR マージ時の 2 重実行が解消）
- runner 時間とコストの削減
- branch protection で main / staging は PR 必須 → 直接 push されないので \`push\` トリガは元々不要

## 既存の他 workflow について
- \`terraform-ci.yml\`: 既に \`pull_request\` のみ（変更不要）
- \`release-please.yml\`: \`push: main\` のまま（リリース専用なので保持）
- \`sync-staging-to-main.yml\`: \`push: staging\` のまま（同期 PR 生成専用なので保持）
- \`deploy.yml\` / \`migrate.yml\`: \`workflow_dispatch\` / \`workflow_call\` のみ（変更不要）

## Test plan
- [ ] この PR の \`pull_request\` トリガで CI / Build / E2E Result / Merge E2E Reports がグリーン
- [ ] マージ後、staging に対する重複 push CI が **起動しない**ことを確認
- [ ] 次の feature → staging PR で 2 重実行されないことを確認