### PR TITLE
chore(ci): restore push trigger on staging to unblock bot-authored sync PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main, staging]
+  push:
+    branches: [staging]
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,8 @@ name: E2E Tests
 on:
   pull_request:
     branches: [main, staging]
+  push:
+    branches: [staging]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 概要
PR #61 で削除した \`push\` トリガを \`staging\` のみ復活させる。bot 作成 PR が絡むシナリオで sync PR の必須 check が満たせない問題を恒久的に解消する。

## 発生していた問題
PR #63 (staging → main sync PR) で必須 check (\`CI\` / \`Build\` / \`E2E Result\` / \`Merge E2E Reports\`) が pending のまま変化せず、マージできない状態になっていた。

### 原因の連鎖
1. **PR #62 (release-please の自動リリース PR) は \`github-actions[bot]\` が作成**
2. GitHub Actions の仕様: \`GITHUB_TOKEN\` で作られた PR は \`pull_request\` トリガを発火しない
   - 参考: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
3. ユーザーが PR #62 を staging にマージ → staging に push イベント発生
4. **PR #61 で ci.yml / e2e.yml の \`push\` トリガを削除していたため**、この push でも CI が走らない
5. 結果、staging HEAD (\`d1ac1ade…\`) に紐づく check-run は sync workflow の 1 件だけ
6. sync PR #63 も bot 作成なので \`pull_request\` トリガが発火しない
7. branch protection の必須 check (\`CI\` / \`Build\` / …) が 1 つも満たされずマージ不可

## 変更内容
\`\`\`yaml
on:
  pull_request:
    branches: [main, staging]
  push:
    branches: [staging]   # ← 追加
\`\`\`

- \`.github/workflows/ci.yml\` と \`.github/workflows/e2e.yml\` の両方に \`push: [staging]\` を追加
- \`main\` は含めない → main マージ時の 2 重実行は引き続き発生しない（release-please が main push で別途起動するため、CI/E2E の重複は不要）

## これで解決する理由
- release-please や sync-staging-to-main の bot PR マージでも、staging への push があれば \`push\` トリガが走り、staging HEAD の commit に \`CI\` / \`Build\` / \`E2E Result\` などの check-run が紐づく
- sync PR #63 の head SHA = staging HEAD なので、check が自動的に PR 上に表示される
- ブランチ保護の必須 check 条件を満たしマージ可能になる

## トレードオフ
- feature branch → staging の**通常 PR マージ時は 2 重実行**に戻る（pull_request + push）
- しかし main マージ時は 2 重実行しないので、PR #61 の主目的（main マージ時の無駄な 2 重実行解消）は維持される
- 冗長性は残るが、bot 自動化フローとの整合性を優先

## PR #63 への波及効果
**この PR を staging にマージすると、副次的に PR #63 の問題も解決します**:
1. この PR のマージで staging に push → 新しい \`push: [staging]\` トリガで CI / E2E が走る
2. 同時に PR #63 の head SHA が staging の新 HEAD に更新 → \`pull_request synchronize\` イベントが発火
3. PR #63 の base は main なので \`pull_request: branches: [main, staging]\` に一致、CI / E2E が走る
4. staging HEAD に check が紐づき、PR #63 の必須 check が満たされる

マージ操作はユーザー（非 bot）が行うため、\`GITHUB_TOKEN\` バイパス制約には該当しません。

## Test plan
- [ ] この PR の \`pull_request\` トリガで CI / Build / E2E Result / Merge E2E Reports がグリーン
- [ ] マージ後、staging への push で ci.yml / e2e.yml が走ることを確認
- [ ] PR #63 の head SHA が更新され、必須 check が満たされることを確認
- [ ] 次回 release-please 自動生成 PR のマージフローでも同じ問題が再発しないことを確認