### PR TITLE
chore(ci): pin release-please target-branch to main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: main
 
   changes:
     name: Detect deployable changes


### PR DESCRIPTION
## 概要
`release-please.yml` の action 呼び出しに `target-branch: main` を明示する。

## 背景
現在、`staging → main` マージ後に release-please が起動すると、本来作られるべき **main ベースの release PR** の代わりに **staging ベースの release PR**（`chore(staging): release 0.2.2` 等）が作られていた。

### 原因
`release-please-action@v4` は `target-branch` が未指定の場合、**リポジトリのデフォルトブランチ**を release 対象として使用する。このリポジトリのデフォルトブランチは現在 `staging` のため、workflow 自体が main push で起動していても、action 内部では staging を対象に release 計算を行っていた。

### 証跡
```
PR #40  base: main     head: release-please--branches--main--...     ← 旧、正常
PR #49  base: staging  head: release-please--branches--staging--...  ← 異常
PR #62  base: staging  head: release-please--branches--staging--...  ← 異常
PR #65  base: staging  head: release-please--branches--staging--...  ← 異常 (現在 open)
```

## 変更内容
```yaml
- name: Run release-please-action
  uses: googleapis/release-please-action@16a9c... # v4.4.0
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    config-file: release-please-config.json
    manifest-file: .release-please-manifest.json
    target-branch: main   # ← 追加
```

変更は 1 行のみ。

## CLAUDE.md の意図との整合
CLAUDE.md のブランチ運用フロー:
```
feature → staging → main → release-please Release PR → 本番自動デプロイ
```
main を release 対象とする設計なので、`target-branch: main` が正しい。

## マージ後の手動作業
1. 現在 open の PR #65 (`chore(staging): release 0.2.2`) を **close**
2. 次回 main push（別 PR が staging → main sync される）で release-please が起動すると、**main base の release PR** が自動生成される
3. 過去の staging release PR 用ブランチ `release-please--branches--staging--components--hut` は役目を終えるので、将来的に削除可能

## `.release-please-manifest.json` の互換性
現在 `{".": "0.2.1"}`。main 側の最新 tag `v0.2.1` と一致しているので、target-branch を main に切り替えても manifest の整合性は崩れない。次回リリースは `0.2.2` として main base で計算される。

## Test plan
- [ ] この PR の `pull_request` トリガで CI / Build / E2E Result / Merge E2E Reports がグリーン
- [ ] マージ後、staging → main の sync PR（PR #63 相当）がマージされた際、**`chore(main): release 0.2.2` のような main base の release PR** が自動生成されることを確認
- [ ] PR #65 を close
- [ ] 将来の `release-please--branches--staging--components--hut` ブランチを削除

## 備考
PR #64 (`chore(ci): restore push trigger on staging`) をマージしてから本 PR のマージを行うと、staging HEAD への check 伝播問題にも引っかからず、スムーズに進みます。