### PR TITLE
feat(infra): GCP 予算アラートを導入する (#72)

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -117,6 +117,8 @@ jobs:
           TF_VAR_authorized_members: ${{ secrets.TF_VAR_AUTHORIZED_MEMBERS }}
           TF_VAR_oauth_client_id: ${{ secrets.TF_VAR_OAUTH_CLIENT_ID }}
           TF_VAR_oauth_client_secret: ${{ secrets.TF_VAR_OAUTH_CLIENT_SECRET }}
+          TF_VAR_billing_account_id: ${{ secrets.TF_VAR_BILLING_ACCOUNT_ID }}
+          TF_VAR_notification_email: ${{ secrets.TF_VAR_NOTIFICATION_EMAIL }}
         run: |
           set +e
           terraform plan -input=false -no-color -lock=false -out=tfplan | tee plan.txt

--- a/docs/internal/runbooks/billing-shutdown.md
+++ b/docs/internal/runbooks/billing-shutdown.md
@@ -1,0 +1,227 @@
+# 課金アラート受信時の手動シャットダウン Runbook
+
+GCP 予算アラート（`billing_budget` モジュールが配信）を受け取ったときに、
+段階的に課金を抑える手順をまとめたものです。Issue #72 の縮小スコープ（案 A）に基づき、
+自動シャットダウンは行わず、人手で確実に止めることを前提とします。
+
+対象環境: stg（月次予算 ¥3,000）/ prd（月次予算 ¥10,000）
+
+しきい値: `0.5`, `0.8`, `1.0`, `1.2`（50/80/100/120 %）。
+通知チャネルはメール 1 つで、stg/prd で同じ送信先を共有することを想定しています。
+
+## 事前準備: 環境変数の設定
+
+この Runbook 内のコマンド例はすべて環境変数を参照しています。実作業に入る前にシェルで以下を設定してください。
+値は 1Password などのシークレットストアや `gh secret list --env stg-plan` / `gh secret list --env prd-plan` で確認できるものを使います。
+
+```bash
+export STG_PROJECT_ID=<GCP stg project id>
+export PRD_PROJECT_ID=<GCP prd project id>
+export BILLING_ACCOUNT_ID=<GCP billing account id>
+export OWNER_EMAIL=<リポジトリ所有者のメールアドレス>
+```
+
+> 緊急度の早見表
+>
+> - 50 % 通知: 観測のみ。Section 1 の確認を実施。
+> - 80 % 通知: 残予算と直近の変更を確認。Section 1 + Section 2 の準備。
+> - 100 % 通知: Section 2 を実行（Workers/Cloud Run の停止）。
+> - 120 % 通知: Section 3 を実行（Firestore rules を全拒否化）。
+
+---
+
+## Section 1: アラート受信時の確認手順
+
+1. **GCP コンソールで実費の内訳を見る**
+
+   - prd: <https://console.cloud.google.com/billing/${BILLING_ACCOUNT_ID}/reports?project=${PRD_PROJECT_ID}>
+   - stg: <https://console.cloud.google.com/billing/${BILLING_ACCOUNT_ID}/reports?project=${STG_PROJECT_ID}>
+
+   ※ URL の billing account ID は実環境のものに置き換えてください。
+
+2. **どのサービスが急増しているかを「Group by service」で確認**
+
+   - `Cloud Firestore`、`Cloud Run`、`Cloud Storage`、`Networking` の上位を確認。
+
+3. **Firestore 使用量ダッシュボードを開く**
+
+   - prd: <https://console.cloud.google.com/firestore/databases/-default-/usage?project=${PRD_PROJECT_ID}>
+   - 直近の Read / Write / Storage 量を確認。
+   - スパイクがあれば、原因となったコレクション（`articles`, `search-tokens` など）を特定。
+
+4. **Cloud Run のリクエスト数とエラー率を確認**
+
+   - prd admin: <https://console.cloud.google.com/run/detail/asia-northeast1/${PRD_PROJECT_ID}-admin/metrics?project=${PRD_PROJECT_ID}>
+   - stg admin: <https://console.cloud.google.com/run/detail/asia-northeast1/${STG_PROJECT_ID}-admin/metrics?project=${STG_PROJECT_ID}>
+   - stg reader: <https://console.cloud.google.com/run/detail/asia-northeast1/${STG_PROJECT_ID}-reader/metrics?project=${STG_PROJECT_ID}>
+   - 1 分あたりリクエスト数が普段より 1 桁以上多ければ、スクレイパや誤設定のジョブを疑う。
+
+5. **Cloudflare ダッシュボードでアクセスログ / ボット検知を確認**（prd reader）
+
+   - <https://dash.cloudflare.com> → 対象 Worker → Analytics & Logs。
+   - WAF / Bot Analytics で異常な国・User-Agent を確認。
+
+6. **直近のデプロイを確認**
+
+   - `git log --since='24 hours ago' main` で最近マージされた変更を確認。
+   - 想定外のキャッシュ無効化や N+1 クエリが入っていないかをコードで確認。
+
+これらで原因が掴めて自然減が見込めるなら、ここで停止せず観測を続けます。
+収束しない／120 % に到達した場合は Section 2 へ進みます。
+
+---
+
+## Section 2: prd reader（Cloudflare Workers）の手動停止手順
+
+prd reader は Cloudflare Workers にデプロイされた静的サイトです。
+GCP 側のリソースではないため、Cloudflare ダッシュボードから切り離します。
+
+1. <https://dash.cloudflare.com> にログイン。
+2. 左メニュー **Workers & Pages** を開く。
+3. 対象の Worker / Pages プロジェクト（reader 本番）を選択。
+4. **Settings** → **Triggers** → **Routes** を開く。
+5. 本番ドメイン（例: `hut.example.com/*`）の Route を **Delete** する。
+   - 完全に削除する代わりに、一時的にダミードメインへ差し替えるのも可。
+6. **Custom Domains** が有効な場合は、対応するドメインを **Disable** に切り替える。
+7. ブラウザで対象 URL にアクセスし、Cloudflare の標準 522 / DNS error が返ることを確認。
+
+> 注意: Worker そのもの（コード）を削除する必要はありません。Routes を外すだけで配信が止まります。
+> 復旧時に Routes を貼り直せば即時復帰できます。
+
+並行して、必要であれば **prd admin / search-token-worker** も止めます。
+これらは Cloud Run なので以下のコマンドで `min-instances`/`max-instances` を 0 にします。
+
+```bash
+gcloud run services update ${PRD_PROJECT_ID}-admin \
+  --region=asia-northeast1 \
+  --project=${PRD_PROJECT_ID} \
+  --min-instances=0 \
+  --max-instances=0
+
+gcloud run services update search-token-worker \
+  --region=asia-northeast1 \
+  --project=${PRD_PROJECT_ID} \
+  --min-instances=0 \
+  --max-instances=0
+
+gcloud run services update image-cleanup-worker \
+  --region=asia-northeast1 \
+  --project=${PRD_PROJECT_ID} \
+  --min-instances=0 \
+  --max-instances=0
+```
+
+`max-instances=0` にすると新規リクエストが即時拒否され、課金対象のインスタンスが立たなくなります。
+イメージや revision はそのまま残るため、復旧時は同じコマンドで `--max-instances=100`（既定値）に戻すだけで配信が再開します。
+
+---
+
+## Section 3: Firestore rules を一時的に全拒否版へ差し替える手順
+
+Firestore の Read / Write が原因で予算を超過しているケースの最終手段です。
+すべてのアクセスを deny に倒し、API 呼び出し数自体をゼロに近づけます。
+
+1. 退避: 現行ルールをタイムスタンプ付きで控える。
+
+   ```bash
+   cp firestore.rules firestore.rules.backup-$(date +%Y%m%d-%H%M%S)
+   ```
+
+2. 差し替え: `firestore.rules` を以下の全拒否版に置き換える。
+
+   ```firestore-rules
+   rules_version = '2';
+   service cloud.firestore {
+     match /databases/{database}/documents {
+       match /{document=**} {
+         allow read, write: if false;
+       }
+     }
+   }
+   ```
+
+3. デプロイ:
+
+   ```bash
+   firebase deploy --only firestore:rules --project ${PRD_PROJECT_ID}
+   firebase deploy --only firestore:rules --project ${STG_PROJECT_ID}
+   ```
+
+4. 確認:
+
+   - Firestore コンソールの「Rules」タブで全拒否ルールが反映されたことを確認。
+   - prd admin の API レスポンスが 403 / permission-denied になることをサンプル確認。
+
+> 注意: この状態では reader / admin 共に一切の読み書きができません。
+> サイト全体が事実上停止するため、Section 2 の Cloudflare Routes 切断と同時に行ってください。
+
+---
+
+## Section 4: 復旧手順（停止解除の逆手順）
+
+原因の修正および予算上限の見直し（必要なら `budget_amount_jpy` の引き上げ PR）を完了した後、
+以下の順に逆操作で復旧します。
+
+1. **Firestore rules を元に戻す**
+
+   ```bash
+   cp firestore.rules.backup-YYYYMMDD-HHMMSS firestore.rules
+   firebase deploy --only firestore:rules --project ${PRD_PROJECT_ID}
+   firebase deploy --only firestore:rules --project ${STG_PROJECT_ID}
+   ```
+
+   - デプロイ後、admin から 1 件 read / write して 200 が返ることを確認。
+
+2. **Cloud Run の max-instances を戻す**
+
+   ```bash
+   gcloud run services update ${PRD_PROJECT_ID}-admin \
+     --region=asia-northeast1 \
+     --project=${PRD_PROJECT_ID} \
+     --min-instances=0 \
+     --max-instances=100
+
+   gcloud run services update search-token-worker \
+     --region=asia-northeast1 \
+     --project=${PRD_PROJECT_ID} \
+     --min-instances=0 \
+     --max-instances=100
+
+   gcloud run services update image-cleanup-worker \
+     --region=asia-northeast1 \
+     --project=${PRD_PROJECT_ID} \
+     --min-instances=0 \
+     --max-instances=100
+   ```
+
+3. **Cloudflare Workers の Routes を再作成**
+
+   - Workers & Pages → 対象プロジェクト → Settings → Triggers → Routes → **Add route**。
+   - 元のドメインパターンを設定（例: `hut.example.com/*`）。
+   - Custom Domains を Disable していた場合は再度 Enable。
+
+4. **動作確認**
+
+   - 本番 URL を開いてトップページが描画されることを確認。
+   - 主要記事ページ・検索ページが描画されることを確認。
+   - admin にログインし、記事の一覧取得・編集を 1 件試す。
+
+5. **事後対応**
+
+   - 課金ダッシュボードを 30 分後・1 時間後・翌朝に再確認し、再発していないか監視。
+   - 原因と再発防止策を `docs/internal/runbooks/billing-shutdown.md` の末尾、
+     または別途 incident note にメモ。
+
+---
+
+## Section 5: 連絡先・エスカレーション
+
+- **一次対応**: リポジトリ所有者（`${OWNER_EMAIL}`）
+- **連絡手段**: GitHub Issue（`infra` ラベル）/ メール
+- **GCP サポート**: 個人プロジェクトのため Basic サポートのみ。
+  クォータ調整など Google 側の操作が必要な場合は GCP コンソールから Support ケースを起票。
+- **Cloudflare サポート**: Free プランのため Community サポートのみ。Routes / DNS のセルフサービスで完結する範囲で運用する。
+
+> このドキュメントは Issue #72（縮小スコープ案 A）に対応します。
+> 自動シャットダウン（Cloud Functions などによる自動 Workers 停止）は実装していないため、
+> 本 Runbook の手動手順が唯一の停止方法です。

--- a/infrastructure/environments/prd/main.tf
+++ b/infrastructure/environments/prd/main.tf
@@ -371,3 +371,15 @@ module "billing_export" {
 
   labels = local.common_labels
 }
+
+module "billing_budget" {
+  source = "../../modules/billing_budget"
+
+  project_id         = var.project_id
+  billing_account_id = var.billing_account_id
+  display_name       = "${var.project_id} monthly budget"
+  budget_amount_jpy  = 10000
+  notification_email = var.notification_email
+
+  labels = local.common_labels
+}

--- a/infrastructure/environments/prd/secrets.auto.tfvars.example
+++ b/infrastructure/environments/prd/secrets.auto.tfvars.example
@@ -1,2 +1,4 @@
 oauth_client_id     = ""
 oauth_client_secret = ""
+billing_account_id  = ""
+notification_email  = ""

--- a/infrastructure/environments/prd/variables.tf
+++ b/infrastructure/environments/prd/variables.tf
@@ -64,3 +64,14 @@ variable "billing_export_location" {
   description = "Geographic location for the billing export BigQuery dataset"
   type        = string
 }
+
+variable "billing_account_id" {
+  description = "GCP billing account ID that owns the project and the monthly budget"
+  type        = string
+}
+
+variable "notification_email" {
+  description = "Email address that receives GCP budget alert notifications"
+  type        = string
+  sensitive   = true
+}

--- a/infrastructure/environments/stg/main.tf
+++ b/infrastructure/environments/stg/main.tf
@@ -358,3 +358,15 @@ module "billing_export" {
 
   labels = local.common_labels
 }
+
+module "billing_budget" {
+  source = "../../modules/billing_budget"
+
+  project_id         = var.project_id
+  billing_account_id = var.billing_account_id
+  display_name       = "${var.project_id} monthly budget"
+  budget_amount_jpy  = 3000
+  notification_email = var.notification_email
+
+  labels = local.common_labels
+}

--- a/infrastructure/environments/stg/secrets.auto.tfvars.example
+++ b/infrastructure/environments/stg/secrets.auto.tfvars.example
@@ -1,2 +1,4 @@
 oauth_client_id     = ""
 oauth_client_secret = ""
+billing_account_id  = ""
+notification_email  = ""

--- a/infrastructure/environments/stg/variables.tf
+++ b/infrastructure/environments/stg/variables.tf
@@ -64,3 +64,14 @@ variable "billing_export_location" {
   description = "Geographic location for the billing export BigQuery dataset"
   type        = string
 }
+
+variable "billing_account_id" {
+  description = "GCP billing account ID that owns the project and the monthly budget"
+  type        = string
+}
+
+variable "notification_email" {
+  description = "Email address that receives GCP budget alert notifications"
+  type        = string
+  sensitive   = true
+}

--- a/infrastructure/modules/billing_budget/README.md
+++ b/infrastructure/modules/billing_budget/README.md
@@ -1,0 +1,57 @@
+# billing_budget
+
+`google_billing_budget` と `google_monitoring_notification_channel` を組み合わせて、
+特定の GCP プロジェクトの月次コストがしきい値を超えたらメール通知を送るモジュールです。
+
+Issue #72 の縮小スコープ（予算アラート通知まで）を実現します。Workers / Firestore の
+自動シャットダウンは行いません。アラート受信後の手動停止手順は
+`docs/internal/runbooks/billing-shutdown.md` を参照してください。
+
+## リソース
+
+- `google_monitoring_notification_channel.email` — 通知先メールのチャネル
+- `google_billing_budget.this` — プロジェクト単位の月次予算と複数しきい値アラート
+
+## 変数
+
+| 名前 | 型 | 必須 | デフォルト | 説明 |
+|------|----|------|------------|------|
+| `billing_account_id` | `string` | はい | — | GCP 請求先アカウント ID（例: `01ABCD-234567-89EFGH`） |
+| `display_name` | `string` | はい | — | GCP コンソールに表示される予算名 |
+| `budget_amount_jpy` | `number` | はい | — | 月額予算（日本円、整数） |
+| `notification_email` | `string` | はい | — | アラート通知の送信先メールアドレス（sensitive） |
+| `project_id` | `string` | はい | — | 監視対象の GCP プロジェクト ID |
+| `threshold_percents` | `list(number)` | いいえ | `[0.5, 0.8, 1.0, 1.2]` | アラートを発火させる予算しきい値（割合） |
+| `labels` | `map(string)` | いいえ | `{}` | 通知チャネルに付与するラベル |
+
+## 出力
+
+| 名前 | 説明 |
+|------|------|
+| `budget_name` | 作成した予算の完全修飾リソース名 |
+| `notification_channel_id` | 作成した通知チャネルの ID |
+
+## 使用例
+
+```hcl
+module "billing_budget" {
+  source = "../../modules/billing_budget"
+
+  project_id         = var.project_id
+  billing_account_id = var.billing_account_id
+  display_name       = "${var.project_id} monthly budget"
+  budget_amount_jpy  = 3000
+  notification_email = var.notification_email
+
+  labels = local.common_labels
+}
+```
+
+## 前提条件
+
+- `cloudbilling.googleapis.com` が有効化されていること
+- `monitoring.googleapis.com` が有効化されていること
+- 実行する Terraform サービスアカウントに
+  `roles/billing.costsManager`（または同等）が付与されていること
+- `notification_email` に指定したアドレスの受信者が
+  GCP Monitoring からの検証メールを承認済みであること（初回のみ）

--- a/infrastructure/modules/billing_budget/main.tf
+++ b/infrastructure/modules/billing_budget/main.tf
@@ -1,0 +1,42 @@
+resource "google_monitoring_notification_channel" "email" {
+  project      = var.project_id
+  display_name = "${var.display_name} email channel"
+  type         = "email"
+
+  labels = {
+    email_address = var.notification_email
+  }
+
+  user_labels = var.labels
+}
+
+resource "google_billing_budget" "this" {
+  billing_account = var.billing_account_id
+  display_name    = var.display_name
+
+  budget_filter {
+    projects = ["projects/${var.project_id}"]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "JPY"
+      units         = tostring(var.budget_amount_jpy)
+    }
+  }
+
+  dynamic "threshold_rules" {
+    for_each = var.threshold_percents
+    content {
+      threshold_percent = threshold_rules.value
+      spend_basis       = "CURRENT_SPEND"
+    }
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = [
+      google_monitoring_notification_channel.email.id,
+    ]
+    disable_default_iam_recipients = false
+  }
+}

--- a/infrastructure/modules/billing_budget/main.tf
+++ b/infrastructure/modules/billing_budget/main.tf
@@ -37,6 +37,6 @@ resource "google_billing_budget" "this" {
     monitoring_notification_channels = [
       google_monitoring_notification_channel.email.id,
     ]
-    disable_default_iam_recipients = false
+    disable_default_iam_recipients = true
   }
 }

--- a/infrastructure/modules/billing_budget/outputs.tf
+++ b/infrastructure/modules/billing_budget/outputs.tf
@@ -1,0 +1,9 @@
+output "budget_name" {
+  description = "Fully qualified resource name of the billing budget"
+  value       = google_billing_budget.this.name
+}
+
+output "notification_channel_id" {
+  description = "Monitoring notification channel identifier for the budget alerts"
+  value       = google_monitoring_notification_channel.email.id
+}

--- a/infrastructure/modules/billing_budget/variables.tf
+++ b/infrastructure/modules/billing_budget/variables.tf
@@ -1,0 +1,74 @@
+variable "billing_account_id" {
+  description = "GCP billing account ID that owns the budget (e.g. 01ABCD-234567-89EFGH)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[A-Z0-9-]+$", var.billing_account_id))
+    error_message = "The billing_account_id must consist of uppercase letters, digits, and hyphens."
+  }
+}
+
+variable "display_name" {
+  description = "Human-readable name for the budget shown in the GCP console"
+  type        = string
+
+  validation {
+    condition     = length(var.display_name) > 0 && length(var.display_name) <= 60
+    error_message = "The display_name must be between 1 and 60 characters."
+  }
+}
+
+variable "budget_amount_jpy" {
+  description = "Monthly budget amount in Japanese yen (JPY). Must be a positive whole number because JPY has no fractional unit."
+  type        = number
+
+  validation {
+    condition     = var.budget_amount_jpy > 0
+    error_message = "The budget_amount_jpy must be greater than zero."
+  }
+
+  validation {
+    condition     = floor(var.budget_amount_jpy) == var.budget_amount_jpy
+    error_message = "The budget_amount_jpy must be a whole number (JPY has no fractional unit)."
+  }
+}
+
+variable "notification_email" {
+  description = "Email address that receives budget alert notifications"
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.notification_email))
+    error_message = "The notification_email must be a valid email address."
+  }
+}
+
+variable "threshold_percents" {
+  description = "Budget threshold fractions that trigger alerts (e.g. 0.5 means 50 percent of the budget)"
+  type        = list(number)
+  default     = [0.5, 0.8, 1.0, 1.2]
+
+  validation {
+    condition     = length(var.threshold_percents) > 0
+    error_message = "At least one threshold percent must be provided."
+  }
+
+  validation {
+    condition = alltrue([
+      for threshold in var.threshold_percents : threshold > 0
+    ])
+    error_message = "Every threshold_percents value must be greater than zero."
+  }
+}
+
+variable "project_id" {
+  description = "GCP project ID that the budget filter monitors"
+  type        = string
+}
+
+variable "labels" {
+  description = "Labels to apply to the notification channel"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/modules/billing_budget/versions.tf
+++ b/infrastructure/modules/billing_budget/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.14"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #72

## Summary

- `infrastructure/modules/billing_budget/` を新設し、GCP Billing Budget リソース（月次予算・複数段階アラート 50%/80%/100%/120%）と Cloud Monitoring のメール通知チャネルを定義
- 自動シャットダウンは行わず、アラート受信時の手動停止手順を `docs/internal/runbooks/billing-shutdown.md` に整備（Issue #72 の縮小スコープ案 A）
- stg（¥3,000/月）・prd（¥10,000/月）両環境の `environments/stg/` および `environments/prd/` へ `billing_budget` モジュールを適用

## Checklist

- [ ] Frontend
- [ ] Backend
- [x] Infrastructure
- [ ] Design